### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+CoreECS is a pure C# library (no servers, no databases, no Docker). It consists of two projects in `CoreECS.sln`:
+
+| Project | Path | Purpose |
+|---------|------|---------|
+| `ECS` | `ECS/ECS.csproj` | Library (targets `net8.0` + `netstandard2.1`) |
+| `Test` | `Test/Test.csproj` | NUnit tests (targets `net8.0`) |
+
+### Prerequisites
+
+- **.NET 8 SDK** is required. The `global.json` pins `8.0.0` with `rollForward: latestMinor`.
+- The update script installs the SDK to `$HOME/.dotnet` and adds it to PATH via `~/.bashrc`.
+
+### Common commands
+
+| Action | Command |
+|--------|---------|
+| Restore | `dotnet restore` |
+| Build | `dotnet build` |
+| Test | `dotnet test --verbosity normal` |
+| Build Release | `dotnet build --configuration Release` |
+
+### Known issues
+
+- Two pre-existing test failures in `EntityCollectorTestUnit`:
+  - `EntityCollector_ChangeComponent_BounceMembership_BetweenFlushes_LeavesConsistentState`
+  - `EntityCollector_NonLazy_RealtimeMatchClash`
+- These are codebase issues, not environment issues. 272/274 tests pass.
+
+### Gotchas
+
+- The .NET SDK is installed to `$HOME/.dotnet`, not `/usr/share/dotnet`. The update script ensures `DOTNET_ROOT` and `PATH` are set in `~/.bashrc`.
+- No lint tool (e.g. `dotnet format`) is configured in the solution. Build warnings serve as the primary code-quality check.
+- The library uses `AllowUnsafeBlocks` and `LangVersion 9`; the test project uses `ImplicitUsings: enable` and `Nullable: enable`—do not unify these settings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,6 @@ CoreECS is a pure C# library (no servers, no databases, no Docker). It consists 
 | Test | `dotnet test --verbosity normal` |
 | Build Release | `dotnet build --configuration Release` |
 
-### Known issues
-
-- Two pre-existing test failures in `EntityCollectorTestUnit`:
-  - `EntityCollector_ChangeComponent_BounceMembership_BetweenFlushes_LeavesConsistentState`
-  - `EntityCollector_NonLazy_RealtimeMatchClash`
-- These are codebase issues, not environment issues. 272/274 tests pass.
-
 ### Gotchas
 
 - The .NET SDK is installed to `$HOME/.dotnet`, not `/usr/share/dotnet`. The update script ensures `DOTNET_ROOT` and `PATH` are set in `~/.bashrc`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

### What's included

- Project overview (ECS library + NUnit test project)
- Prerequisites (.NET 8 SDK)
- Common commands table (restore, build, test)
- Known pre-existing test failures (2 of 274 tests)
- Environment gotchas (SDK install path, project config differences)

### Evidence of working environment

**Hello ECS Demo** — World lifecycle, Entity/Component CRUD, Collector matching, and Tick loop all verified:

[hello_ecs_demo.log](https://cursor.com/agents/bc-18bfd657-7b4d-40df-8e36-c843219836dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_ecs_demo.log)

**Test suite** — 272/274 tests pass (2 pre-existing failures):

[test_output.log](https://cursor.com/agents/bc-18bfd657-7b4d-40df-8e36-c843219836dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18bfd657-7b4d-40df-8e36-c843219836dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18bfd657-7b4d-40df-8e36-c843219836dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

