### PR TITLE
EntityCollector: always use deferred flush, remove Lazy flags

### DIFF
--- a/ECS/Defines/IEntityCollector.cs
+++ b/ECS/Defines/IEntityCollector.cs
@@ -4,47 +4,60 @@ using System.Collections.Generic;
 namespace CoreECS.Defines
 {
     /// <summary>
-    /// Flags that control the behavior of entity collectors.
+    /// Flags that control which entity events are mirrored into <see cref="IEntityCollector.Changed"/>.
+    /// Collectors always defer <see cref="IEntityCollector.Collected"/>,
+    /// <see cref="IEntityCollector.Matching"/>, <see cref="IEntityCollector.Clashing"/>, and
+    /// <see cref="IEntityCollector.Changed"/> until <see cref="IEntityCollector.Flush"/> is called.
     /// </summary>
     [Flags]
     public enum EntityCollectorFlag
     {
         /// <summary>
-        /// No special behavior.
+        /// No events are mirrored into <see cref="IEntityCollector.Changed"/>.
+        /// Membership enter/leave is still tracked in <see cref="IEntityCollector.Matching"/> and
+        /// <see cref="IEntityCollector.Clashing"/> after <see cref="IEntityCollector.Flush"/>.
         /// </summary>
         None = 0,
 
         /// <summary>
-        /// Include entities with component revision changes in Changed.
+        /// Mirror entities whose tracked component <em>data</em> changed (revision) into
+        /// <see cref="IEntityCollector.Changed"/>.
         /// </summary>
         RevisionAsChange = 1 << 0,
 
         /// <summary>
-        /// Include entities entering collector in Changed.
+        /// Mirror entities <em>entering</em> the collector (structural match) into
+        /// <see cref="IEntityCollector.Changed"/>.
         /// </summary>
         MatchAsChange = 1 << 1,
 
         /// <summary>
-        /// Include entities leaving collector in Changed.
+        /// Mirror entities <em>leaving</em> the collector (structural clash) into
+        /// <see cref="IEntityCollector.Changed"/>.
         /// </summary>
         ClashAsChange = 1 << 2,
 
         /// <summary>
-        /// When set, only Match related component changes will be
-        /// tracked in the Changed buffer. When not set, all component
-        /// changes are tracked regardless of component type relevance.
+        /// Limit component-driven <see cref="IEntityCollector.Changed"/> entries to component types
+        /// relevant to the collector matcher. When unset, all component add/remove/revision events
+        /// that reach the collector are eligible for <see cref="IEntityCollector.Changed"/>.
         /// </summary>
         RelatedComponentOnly = 1 << 3,
 
         /// <summary>
-        /// Default collector behavior.
+        /// Default structural-change collector: newly matching entities and match-relevant
+        /// composition/revision updates while collected are mirrored into
+        /// <see cref="IEntityCollector.Changed"/>; departures stay in
+        /// <see cref="IEntityCollector.Clashing"/> unless <see cref="ClashAsChange"/> is added.
         /// </summary>
         Default = RevisionAsChange | MatchAsChange | RelatedComponentOnly,
 
     }
     
     /// <summary>
-    /// Collects entities that satisfy a matcher's criteria.
+    /// Collects entities that satisfy a matcher and summarizes structural membership changes
+    /// per <see cref="Flush"/> phase. <see cref="Changed"/> reports which collected entities
+    /// should be reprocessed, according to <see cref="EntityCollectorFlag"/>.
     /// </summary>
     public interface IEntityCollector : IDisposable
     {
@@ -54,27 +67,32 @@ namespace CoreECS.Defines
         public IEntityMatcher Matcher { get; }
 
         /// <summary>
-        /// Gets all collected entities.
+        /// Gets entities currently in the collector after the last <see cref="Flush"/>.
         /// </summary>
         public IReadOnlyList<ulong> Collected { get; }
 
         /// <summary>
-        /// Gets entities that were previously excluded from collector and are now being collected.
+        /// Gets entities that entered the collector during the last flush phase (structural match).
         /// </summary>
         public IReadOnlyList<ulong> Matching { get; }
 
         /// <summary>
-        /// Gets entities that were previously included in collector and are now being excluded.
+        /// Gets entities that left the collector during the last flush phase (structural clash).
         /// </summary>
         public IReadOnlyList<ulong> Clashing { get; }
 
         /// <summary>
-        /// Gets entities that changed during the previous collecting phase.
+        /// Gets entities to reprocess from the last flush phase. With
+        /// <see cref="EntityCollectorFlag.Default"/>, this is the structural-change view of the
+        /// collector: newly matching entities plus match-relevant composition/revision updates
+        /// while still collected. Departures are listed in <see cref="Clashing"/> unless
+        /// <see cref="EntityCollectorFlag.ClashAsChange"/> is enabled. Use flags to include or
+        /// exclude additional categories.
         /// </summary>
         public IReadOnlyList<ulong> Changed { get; }
 
         /// <summary>
-        /// Summarizes previous changes and starts a new collecting phase.
+        /// Publishes pending membership and change buffers, then starts a new collecting phase.
         /// </summary>
         public void Flush();
 

--- a/ECS/Defines/IEntityCollector.cs
+++ b/ECS/Defines/IEntityCollector.cs
@@ -17,24 +17,24 @@ namespace CoreECS.Defines
         /// <summary>
         /// Include entities with component revision changes in Changed.
         /// </summary>
-        RevisionAsChange = 1 << 2,
+        RevisionAsChange = 1 << 0,
 
         /// <summary>
         /// Include entities entering collector in Changed.
         /// </summary>
-        MatchAsChange = 1 << 3,
+        MatchAsChange = 1 << 1,
 
         /// <summary>
         /// Include entities leaving collector in Changed.
         /// </summary>
-        ClashAsChange = 1 << 4,
+        ClashAsChange = 1 << 2,
 
         /// <summary>
         /// When set, only Match related component changes will be
         /// tracked in the Changed buffer. When not set, all component
         /// changes are tracked regardless of component type relevance.
         /// </summary>
-        RelatedComponentOnly = 1 << 6,
+        RelatedComponentOnly = 1 << 3,
 
         /// <summary>
         /// Default collector behavior.

--- a/ECS/Defines/IEntityCollector.cs
+++ b/ECS/Defines/IEntityCollector.cs
@@ -17,29 +17,29 @@ namespace CoreECS.Defines
         /// <summary>
         /// Include entities with component revision changes in Changed.
         /// </summary>
-        ChangedOnRevision = 1 << 2,
+        RevisionAsChange = 1 << 2,
 
         /// <summary>
         /// Include entities entering collector in Changed.
         /// </summary>
-        ChangedOnMatching = 1 << 3,
+        MatchAsChange = 1 << 3,
 
         /// <summary>
         /// Include entities leaving collector in Changed.
         /// </summary>
-        ChangedOnClashing = 1 << 4,
+        ClashAsChange = 1 << 4,
 
         /// <summary>
         /// When set, only Match related component changes will be
         /// tracked in the Changed buffer. When not set, all component
         /// changes are tracked regardless of component type relevance.
         /// </summary>
-        ChangeMustBeRelatedComponent = 1 << 6,
+        RelatedComponentOnly = 1 << 6,
 
         /// <summary>
         /// Default collector behavior.
         /// </summary>
-        Default = ChangedOnRevision | ChangedOnMatching | ChangeMustBeRelatedComponent,
+        Default = RevisionAsChange | MatchAsChange | RelatedComponentOnly,
 
     }
     

--- a/ECS/Defines/IEntityCollector.cs
+++ b/ECS/Defines/IEntityCollector.cs
@@ -13,21 +13,6 @@ namespace CoreECS.Defines
         /// No special behavior.
         /// </summary>
         None = 0,
-        
-        /// <summary>
-        /// Don't remove elements from Collected before Change() is called.
-        /// </summary>
-        LazyRemove = 1 << 0,
-        
-        /// <summary>
-        /// Don't add elements from Collected before Change() is called.
-        /// </summary>
-        LazyAdd = 1 << 1,
-
-        /// <summary>
-        /// Don't change elements in Collected before Change() is called.
-        /// </summary>
-        Lazy = LazyRemove | LazyAdd,
 
         /// <summary>
         /// Include entities with component revision changes in Changed.
@@ -45,11 +30,6 @@ namespace CoreECS.Defines
         ChangedOnClashing = 1 << 4,
 
         /// <summary>
-        /// Don't update Changed before Flush() is called.
-        /// </summary>
-        LazyChange = 1 << 5,
-
-        /// <summary>
         /// When set, only Match related component changes will be
         /// tracked in the Changed buffer. When not set, all component
         /// changes are tracked regardless of component type relevance.
@@ -59,7 +39,7 @@ namespace CoreECS.Defines
         /// <summary>
         /// Default collector behavior.
         /// </summary>
-        Default = Lazy | LazyChange | ChangedOnRevision | ChangedOnMatching | ChangeMustBeRelatedComponent,
+        Default = ChangedOnRevision | ChangedOnMatching | ChangeMustBeRelatedComponent,
 
     }
     

--- a/ECS/Managers/EntityMatchManager.cs
+++ b/ECS/Managers/EntityMatchManager.cs
@@ -100,21 +100,6 @@ namespace CoreECS.Managers
             public bool Destroyed { get; private set; } = false;
 
             /// <summary>
-            /// Gets a value indicating whether matching entities should be deferred until <see cref="Flush"/>.
-            /// </summary>
-            public readonly bool HasLazyAdd;
-
-            /// <summary>
-            /// Gets a value indicating whether removals should be deferred until <see cref="Flush"/>.
-            /// </summary>
-            public readonly bool HasLazyRemove;
-
-            /// <summary>
-            /// Gets a value indicating whether changed entities should be deferred until <see cref="Flush"/>.
-            /// </summary>
-            public readonly bool HasLazyChange;
-
-            /// <summary>
             /// Gets a value indicating whether revision-only updates should appear in the changed buffer.
             /// </summary>
             public readonly bool TrackRevisionChanged;
@@ -140,38 +125,19 @@ namespace CoreECS.Managers
             /// </summary>
             public void Flush()
             {
-                if (HasLazyChange)
-                {
-                    // Swap both the ordered buffers and their membership indexes together,
-                    // otherwise the hash sets would describe the wrong side of the double buffer.
-                    (Buffers[1], Buffers[2], Buffers[3], Buffers[4], Buffers[5], Buffers[6]) =
-                        (Buffers[4], Buffers[5], Buffers[6], Buffers[1], Buffers[2], Buffers[3]);
-                    (BufferSets[1], BufferSets[2], BufferSets[3], BufferSets[4], BufferSets[5], BufferSets[6]) =
-                        (BufferSets[4], BufferSets[5], BufferSets[6], BufferSets[1], BufferSets[2], BufferSets[3]);
-                }
-                else
-                {
-                    // Matching and clashing are always flush-based summaries,
-                    // but Changed is realtime when LazyChange is disabled.
-                    (Buffers[1], Buffers[2], Buffers[4], Buffers[5]) =
-                        (Buffers[4], Buffers[5], Buffers[1], Buffers[2]);
-                    (BufferSets[1], BufferSets[2], BufferSets[4], BufferSets[5]) =
-                        (BufferSets[4], BufferSets[5], BufferSets[1], BufferSets[2]);
-                }
+                // Swap both the ordered buffers and their membership indexes together,
+                // otherwise the hash sets would describe the wrong side of the double buffer.
+                (Buffers[1], Buffers[2], Buffers[3], Buffers[4], Buffers[5], Buffers[6]) =
+                    (Buffers[4], Buffers[5], Buffers[6], Buffers[1], Buffers[2], Buffers[3]);
+                (BufferSets[1], BufferSets[2], BufferSets[3], BufferSets[4], BufferSets[5], BufferSets[6]) =
+                    (BufferSets[4], BufferSets[5], BufferSets[6], BufferSets[1], BufferSets[2], BufferSets[3]);
                 
                 // Clear previous change buffers
                 ClearBuffer(CHANGE_MATCHING_BUFFER_INDEX);
                 ClearBuffer(CHANGE_CLASHING_BUFFER_INDEX);
                 ClearBuffer(CHANGE_CHANGED_BUFFER_INDEX);
-                if (!HasLazyChange)
-                {
-                    // Start a fresh phase for realtime changed tracking.
-                    ClearBuffer(CHANGED_BUFFER_INDEX);
-                }
                 
                 // Copy data from back to front
-                var processRemove = HasLazyRemove;
-                var processAdd = HasLazyAdd;
                 var collected = Buffers[COLLECTED_BUFFER_INDEX];
                 var collectedSet = BufferSets[COLLECTED_BUFFER_INDEX];
                 var changedMatch = Buffers[MATCHING_BUFFER_INDEX];
@@ -181,7 +147,7 @@ namespace CoreECS.Managers
                 // Must do a removal at the end of match and start of change
                 var newLength = collected.Count;
                 
-                if (processRemove && changedClash.Count > 0)
+                if (changedClash.Count > 0)
                 {
                     
                     // Phantom entities are entities that are in clashing buffer but not in collected buffer
@@ -223,7 +189,7 @@ namespace CoreECS.Managers
                 }
 
                 // Update back buffer to ensure alignment with front buffer
-                if (processAdd && changedMatch.Count > 0)
+                if (changedMatch.Count > 0)
                 {
                     var startAt = newLength;
                     var appended = 0;
@@ -292,9 +258,6 @@ namespace CoreECS.Managers
             {
                 Matcher = matcher;
                 Flag = flag;
-                HasLazyAdd = (flag & EntityCollectorFlag.LazyAdd) > 0;
-                HasLazyRemove = (flag & EntityCollectorFlag.LazyRemove) > 0;
-                HasLazyChange = (flag & EntityCollectorFlag.LazyChange) > 0;
                 TrackRevisionChanged = (flag & EntityCollectorFlag.ChangedOnRevision) > 0;
                 TrackMatchChanged = (flag & EntityCollectorFlag.ChangedOnMatching) > 0;
                 TrackClashChanged = (flag & EntityCollectorFlag.ChangedOnClashing) > 0;
@@ -337,8 +300,7 @@ namespace CoreECS.Managers
             /// <param name="entityId">Entity identifier to mark as changed.</param>
             public void MarkChanged(ulong entityId)
             {
-                var targetBuffer = HasLazyChange ? CHANGE_CHANGED_BUFFER_INDEX : CHANGED_BUFFER_INDEX;
-                AddUniqueToBuffer(targetBuffer, entityId);
+                AddUniqueToBuffer(CHANGE_CHANGED_BUFFER_INDEX, entityId);
             }
 
             /// <summary>
@@ -477,17 +439,14 @@ namespace CoreECS.Managers
             // Quick-pass filter
             if ((matcher.EntityMask & entityGraph.Mask) == 0) return;
             
-            // Config
-            var dontAdd = collector.HasLazyAdd;
-            var dontRemove = collector.HasLazyRemove;
             var entityId = entityGraph.EntityId;
             
-            // LazyAdd can make an entity "already collected" before it reaches Collected,
-            // while LazyRemove can keep it in Collected even after it is scheduled to leave.
+            // Pending match/clash buffers can make an entity "already collected" before it
+            // reaches Collected, or keep it in Collected after it is scheduled to leave.
             var alreadyCollected = !init &&
                 (collector.ContainsInBuffer(COLLECTED_BUFFER_INDEX, entityId) ||
-                 (dontAdd && collector.ContainsInBuffer(CHANGE_MATCHING_BUFFER_INDEX, entityId))) &&
-                !(dontRemove && collector.ContainsInBuffer(CHANGE_CLASHING_BUFFER_INDEX, entityId));
+                 collector.ContainsInBuffer(CHANGE_MATCHING_BUFFER_INDEX, entityId)) &&
+                !collector.ContainsInBuffer(CHANGE_CLASHING_BUFFER_INDEX, entityId);
             
             var isMatched = !entityGraph.WishDestroy && matcher.ComponentFilter(entityGraph.RwComponents);
 
@@ -510,7 +469,6 @@ namespace CoreECS.Managers
 
             if (isMatched)
             {
-                if (!dontAdd) collector.AddUniqueToBuffer(COLLECTED_BUFFER_INDEX, entityId);
                 collector.RemoveFromBuffer(CHANGE_CLASHING_BUFFER_INDEX, entityId);
                 collector.AddUniqueToBuffer(CHANGE_MATCHING_BUFFER_INDEX, entityId);
 
@@ -519,7 +477,6 @@ namespace CoreECS.Managers
             }
             else
             {
-                if (!dontRemove) collector.RemoveFromBuffer(COLLECTED_BUFFER_INDEX, entityId);
                 collector.RemoveFromBuffer(CHANGE_MATCHING_BUFFER_INDEX, entityId);
                 collector.AddUniqueToBuffer(CHANGE_CLASHING_BUFFER_INDEX, entityId);
 

--- a/ECS/Managers/EntityMatchManager.cs
+++ b/ECS/Managers/EntityMatchManager.cs
@@ -90,7 +90,7 @@ namespace CoreECS.Managers
             public IReadOnlyList<ulong> Clashing => Buffers[CLASHING_BUFFER_INDEX];
 
             /// <summary>
-            /// Gets the changed entities buffer.
+            /// Gets the published changed-entity buffer for the current flush phase.
             /// </summary>
             public IReadOnlyList<ulong> Changed => Buffers[CHANGED_BUFFER_INDEX];
 
@@ -100,23 +100,26 @@ namespace CoreECS.Managers
             public bool Destroyed { get; private set; } = false;
 
             /// <summary>
-            /// Gets a value indicating whether revision-only updates should appear in the changed buffer.
+            /// Gets a value indicating whether component data revisions are mirrored into
+            /// <see cref="Changed"/>.
             /// </summary>
             public readonly bool TrackRevisionChanged;
 
             /// <summary>
-            /// Gets a value indicating whether entities entering the collector should appear in the changed buffer.
+            /// Gets a value indicating whether entities entering the collector are mirrored into
+            /// <see cref="Changed"/>.
             /// </summary>
             public readonly bool TrackMatchChanged;
 
             /// <summary>
-            /// Gets a value indicating whether entities leaving the collector should appear in the changed buffer.
+            /// Gets a value indicating whether entities leaving the collector are mirrored into
+            /// <see cref="Changed"/>.
             /// </summary>
             public readonly bool TrackClashChanged;
 
             /// <summary>
-            /// Gets a value indicating whether only match-relevant component changes
-            /// should be tracked in the changed buffer.
+            /// Gets a value indicating whether component-driven <see cref="Changed"/> entries are
+            /// limited to matcher-relevant component types.
             /// </summary>
             public readonly bool HasChangeComponent;
 
@@ -295,7 +298,7 @@ namespace CoreECS.Managers
             }
 
             /// <summary>
-            /// Marks an entity as changed in either realtime or deferred mode.
+            /// Queues an entity for the next <see cref="Flush"/> <see cref="Changed"/> publish.
             /// </summary>
             /// <param name="entityId">Entity identifier to mark as changed.</param>
             public void MarkChanged(ulong entityId)
@@ -458,7 +461,7 @@ namespace CoreECS.Managers
                 return;
             }
 
-            // Membership unchanged, but structure still changed while the entity stayed in the collector.
+            // Membership unchanged, but match-relevant composition changed while still collected.
             if (!(isMatched ^ alreadyCollected))
             {
                 if (alreadyCollected && isMatched
@@ -486,9 +489,10 @@ namespace CoreECS.Managers
         }
 
         /// <summary>
-        /// Determines whether a component type change should be tracked
-        /// based on the ChangeComponent flag and matcher relevance.
-        /// When null, or HasChangeComponent is false, always passes.
+        /// Determines whether a component event should be mirrored into <see cref="Collector.Changed"/>
+        /// based on <see cref="EntityCollectorFlag.RelatedComponentOnly"/> and matcher relevance.
+        /// When <paramref name="componentType"/> is null, or <see cref="Collector.HasChangeComponent"/>
+        /// is false, always passes.
         /// </summary>
         private static bool RelevanceGate(Collector collector, IEntityMatcher matcher, Type componentType)
         {

--- a/ECS/Managers/EntityMatchManager.cs
+++ b/ECS/Managers/EntityMatchManager.cs
@@ -258,10 +258,10 @@ namespace CoreECS.Managers
             {
                 Matcher = matcher;
                 Flag = flag;
-                TrackRevisionChanged = (flag & EntityCollectorFlag.ChangedOnRevision) > 0;
-                TrackMatchChanged = (flag & EntityCollectorFlag.ChangedOnMatching) > 0;
-                TrackClashChanged = (flag & EntityCollectorFlag.ChangedOnClashing) > 0;
-                HasChangeComponent = (flag & EntityCollectorFlag.ChangeMustBeRelatedComponent) > 0;
+                TrackRevisionChanged = (flag & EntityCollectorFlag.RevisionAsChange) > 0;
+                TrackMatchChanged = (flag & EntityCollectorFlag.MatchAsChange) > 0;
+                TrackClashChanged = (flag & EntityCollectorFlag.ClashAsChange) > 0;
+                HasChangeComponent = (flag & EntityCollectorFlag.RelatedComponentOnly) > 0;
                 m_manager = manager;
             }
 

--- a/ECS/README.md
+++ b/ECS/README.md
@@ -329,32 +329,19 @@ for (int i = 0; i < positionCollector.Collected.Count; i++)
 
 #### Collector Flags
 
-Collectors support different behaviors through flags. The default flag is `EntityCollectorFlag.Default`:
+Collectors always defer updates to `Collected`, `Matching`, `Clashing`, and `Changed` until `Flush()` is called. Use flags to control which change categories appear in `Changed`. The default flag is `EntityCollectorFlag.Default`:
 
 ```csharp
-// None - entities are immediately added/removed from Collected
-var immediateCollector = world.CreateCollector(
-    EntityMatcher.With.OfAll<PositionComponent>(),
-    EntityCollectorFlag.None
-);
-
-// LazyAdd - newly matching entities won't appear in Collected until Flush() is called
-var lazyAddCollector = world.CreateCollector(
-    EntityMatcher.With.OfAll<PositionComponent>(),
-    EntityCollectorFlag.LazyAdd
-);
-
-// LazyRemove - entities won't be removed from Collected until Flush() is called
-var lazyRemoveCollector = world.CreateCollector(
-    EntityMatcher.With.OfAll<PositionComponent>(),
-    EntityCollectorFlag.LazyRemove
-);
-
 // Default (used when no flag is specified):
-// Lazy + ChangedOnRevision + ChangedOnMatching
-var lazyCollector = world.CreateCollector(
+// ChangedOnRevision + ChangedOnMatching + ChangeMustBeRelatedComponent
+var collector = world.CreateCollector(
     EntityMatcher.With.OfAll<PositionComponent>()
-    // EntityCollectorFlag.Default is used by default
+);
+
+// Include entities that leave the collector in Changed
+var clashTrackingCollector = world.CreateCollector(
+    EntityMatcher.With.OfAll<PositionComponent>(),
+    EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing
 );
 ```
 
@@ -395,7 +382,7 @@ foreach (var entityId in clashingEntities)
 - `ChangedOnMatching`: include entities that newly enter the collector (default includes this).
 - `ChangedOnClashing`: include entities that leave the collector (disabled by default, enable explicitly when needed).
 
-With `EntityCollectorFlag.Default`, `Changed` includes revision changes and newly matching entities, but not clashing entities.
+With `EntityCollectorFlag.Default`, `Changed` includes revision changes and newly matching entities, but not clashing entities. All buffers are published when you call `Flush()`.
 
 #### Best Practices for Using Collectors
 
@@ -430,8 +417,8 @@ public void OnDestroy()
 ```
 
 4. **Choose appropriate flags** based on your use case:
-   - Use `Lazy` flag when you want to process all changes at once in a predictable manner
-   - Use `None` flag when you need immediate updates to the collection
+   - Call `Flush()` once per frame (or phase) to publish buffered membership and change lists
+   - Enable `ChangedOnClashing` when systems need to react to entities leaving the collector
 
 
 ### 11. Complete Example

--- a/ECS/README.md
+++ b/ECS/README.md
@@ -333,7 +333,7 @@ Collectors always defer updates to `Collected`, `Matching`, `Clashing`, and `Cha
 
 ```csharp
 // Default (used when no flag is specified):
-// ChangedOnRevision + ChangedOnMatching + ChangeMustBeRelatedComponent
+// ChangedOnRevision + MatchAsChange + ChangeMustBeRelatedComponent
 var collector = world.CreateCollector(
     EntityMatcher.With.OfAll<PositionComponent>()
 );
@@ -379,7 +379,7 @@ foreach (var entityId in clashingEntities)
 `Changed` behavior depends on collector flags:
 
 - `ChangedOnRevision`: include entities whose component data changed (default includes this).
-- `ChangedOnMatching`: include entities that newly enter the collector (default includes this).
+- `MatchAsChange`: include entities that newly enter the collector (default includes this).
 - `ChangedOnClashing`: include entities that leave the collector (disabled by default, enable explicitly when needed).
 
 With `EntityCollectorFlag.Default`, `Changed` includes revision changes and newly matching entities, but not clashing entities. All buffers are published when you call `Flush()`.

--- a/ECS/README.md
+++ b/ECS/README.md
@@ -161,7 +161,7 @@ Console.WriteLine($"Total components: {allComponents.Length}");
 #### RO / RW Access Notes
 
 - `RO` is read-only access and should be preferred when you only need to inspect values.
-- `RW` is writable access; modifying through `RW` marks the component as changed and can trigger collector revision tracking (`ChangedOnRevision`).
+- `RW` is writable access; modifying through `RW` marks the component as changed and can trigger collector revision tracking (`RevisionAsChange`).
 - If you only want to read in hot paths, avoid accidental writes through `RW` to prevent unnecessary change events.
 
 #### Helper Extension Methods
@@ -329,25 +329,39 @@ for (int i = 0; i < positionCollector.Collected.Count; i++)
 
 #### Collector Flags
 
-Collectors always defer updates to `Collected`, `Matching`, `Clashing`, and `Changed` until `Flush()` is called. Use flags to control which change categories appear in `Changed`. The default flag is `EntityCollectorFlag.Default`:
+Collectors are **structural-change collectors**: `Collected`, `Matching`, `Clashing`, and `Changed` always reflect the last `Flush()` phase. Call `Flush()` once per frame (or phase) before reading any buffer.
+
+`EntityCollectorFlag` controls which events are **also** mirrored into `Changed`. Membership enter/leave is always recorded in `Matching` / `Clashing`; flags decide whether those (or other) events appear in `Changed` too.
+
+`EntityCollectorFlag.Default` (used when no flag is passed) configures `Changed` for the usual structural workflow:
+
+- **Structural match** — entities entering the collector (`MatchAsChange`)
+- **Structural composition** — match-relevant component add/remove while the entity stays collected (`RelatedComponentOnly`)
+- **Data revision** — match-relevant component value updates (`RevisionAsChange` + `RelatedComponentOnly`)
+- **Not included by default** — entities leaving the collector (see `Clashing`; add `ClashAsChange` to mirror departures into `Changed`)
 
 ```csharp
-// Default (used when no flag is specified):
-// ChangedOnRevision + MatchAsChange + ChangeMustBeRelatedComponent
+// Default structural-change collector
 var collector = world.CreateCollector(
     EntityMatcher.With.OfAll<PositionComponent>()
 );
 
-// Include entities that leave the collector in Changed
+// Also mirror entities that leave the collector into Changed
 var clashTrackingCollector = world.CreateCollector(
     EntityMatcher.With.OfAll<PositionComponent>(),
-    EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing
+    EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange
+);
+
+// Changed disabled; use Matching/Clashing/Collected only
+var membershipOnlyCollector = world.CreateCollector(
+    EntityMatcher.With.OfAll<PositionComponent>(),
+    EntityCollectorFlag.None
 );
 ```
 
 #### Change Tracking
 
-Collectors track which entities have changed since the last `Flush()` call:
+After `Flush()`, inspect the buffers from the completed phase:
 
 ```csharp
 var collector = world.CreateCollector(
@@ -376,13 +390,15 @@ foreach (var entityId in clashingEntities)
 }
 ```
 
-`Changed` behavior depends on collector flags:
+Flag reference:
 
-- `ChangedOnRevision`: include entities whose component data changed (default includes this).
-- `MatchAsChange`: include entities that newly enter the collector (default includes this).
-- `ChangedOnClashing`: include entities that leave the collector (disabled by default, enable explicitly when needed).
+- `RevisionAsChange` — mirror component **data** revisions into `Changed` (included in `Default`).
+- `MatchAsChange` — mirror entities **entering** the collector into `Changed` (included in `Default`).
+- `ClashAsChange` — mirror entities **leaving** the collector into `Changed` (not in `Default`; `Clashing` always lists departures after `Flush()`).
+- `RelatedComponentOnly` — limit component-driven `Changed` entries to matcher-relevant types (included in `Default`).
+- `None` — do not mirror any category into `Changed`; structural membership is still available via `Matching` / `Clashing`.
 
-With `EntityCollectorFlag.Default`, `Changed` includes revision changes and newly matching entities, but not clashing entities. All buffers are published when you call `Flush()`.
+With `EntityCollectorFlag.Default`, treat `Changed` as the set of collected entities that need reprocessing after structural or match-relevant data updates. Entities that stop matching appear in `Clashing`, not `Changed`, unless you add `ClashAsChange`.
 
 #### Best Practices for Using Collectors
 
@@ -418,7 +434,7 @@ public void OnDestroy()
 
 4. **Choose appropriate flags** based on your use case:
    - Call `Flush()` once per frame (or phase) to publish buffered membership and change lists
-   - Enable `ChangedOnClashing` when systems need to react to entities leaving the collector
+   - Enable `ClashAsChange` when systems need to react to entities leaving the collector
 
 
 ### 11. Complete Example

--- a/ECS/World.cs
+++ b/ECS/World.cs
@@ -315,10 +315,10 @@ namespace CoreECS
         }
 
         /// <summary>
-        /// Creates a new entity collector with the specified matcher and flag.
+        /// Creates a structural-change entity collector for the specified matcher.
         /// </summary>
         /// <param name="matcher">The entity matcher to use for filtering entities</param>
-        /// <param name="flag">The flag to use for the collector</param>
+        /// <param name="flag">Flags controlling which events are mirrored into <see cref="IEntityCollector.Changed"/>; defaults to <see cref="EntityCollectorFlag.Default"/></param>
         /// <returns>A new IEntityCollector instance</returns>
         /// <exception cref="InvalidOperationException">Thrown when EntityMatch manager is not available</exception>
         public IEntityCollector CreateCollector(IEntityMatcher matcher,

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Console.WriteLine($"Total components: {allComponents.Length}");
 #### RO / RW Access Notes
 
 - `RO` is read-only access and should be preferred when you only need to inspect values.
-- `RW` is writable access; modifying through `RW` marks the component as changed and can trigger collector revision tracking (`ChangedOnRevision`).
+- `RW` is writable access; modifying through `RW` marks the component as changed and can trigger collector revision tracking (`RevisionAsChange`).
 - If you only want to read in hot paths, avoid accidental writes through `RW` to prevent unnecessary change events.
 
 #### Helper Extension Methods
@@ -351,7 +351,7 @@ var lazyRemoveCollector = world.CreateCollector(
 );
 
 // Default (used when no flag is specified):
-// Lazy + LazyChange + ChangedOnRevision + ChangedOnMatching
+// Lazy + LazyChange + RevisionAsChange + ChangedOnMatching
 var lazyCollector = world.CreateCollector(
     EntityMatcher.With.OfAll<PositionComponent>()
     // EntityCollectorFlag.Default is used by default
@@ -391,7 +391,7 @@ foreach (var entityId in clashingEntities)
 
 `Changed` behavior depends on collector flags:
 
-- `ChangedOnRevision`: include entities whose component data changed (default includes this).
+- `RevisionAsChange`: include entities whose component data changed (default includes this).
 - `ChangedOnMatching`: include entities that newly enter the collector (default includes this).
 - `ChangedOnClashing`: include entities that leave the collector (disabled by default, enable explicitly when needed).
 - `LazyChange`: defer updates to `Changed` until `Flush()`; when not enabled, `Changed` updates immediately on events.

--- a/README.md
+++ b/README.md
@@ -329,38 +329,39 @@ for (int i = 0; i < positionCollector.Collected.Count; i++)
 
 #### Collector Flags
 
-Collectors support different behaviors through flags. The default flag is `EntityCollectorFlag.Default`:
+Collectors are **structural-change collectors**: `Collected`, `Matching`, `Clashing`, and `Changed` always reflect the last `Flush()` phase. Call `Flush()` once per frame (or phase) before reading any buffer.
+
+`EntityCollectorFlag` controls which events are **also** mirrored into `Changed`. Membership enter/leave is always recorded in `Matching` / `Clashing`; flags decide whether those (or other) events appear in `Changed` too.
+
+`EntityCollectorFlag.Default` (used when no flag is passed) configures `Changed` for the usual structural workflow:
+
+- **Structural match** — entities entering the collector (`MatchAsChange`)
+- **Structural composition** — match-relevant component add/remove while the entity stays collected (`RelatedComponentOnly`)
+- **Data revision** — match-relevant component value updates (`RevisionAsChange` + `RelatedComponentOnly`)
+- **Not included by default** — entities leaving the collector (see `Clashing`; add `ClashAsChange` to mirror departures into `Changed`)
 
 ```csharp
-// None - entities are immediately added/removed from Collected
-var immediateCollector = world.CreateCollector(
+// Default structural-change collector
+var collector = world.CreateCollector(
+    EntityMatcher.With.OfAll<PositionComponent>()
+);
+
+// Also mirror entities that leave the collector into Changed
+var clashTrackingCollector = world.CreateCollector(
+    EntityMatcher.With.OfAll<PositionComponent>(),
+    EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange
+);
+
+// Changed disabled; use Matching/Clashing/Collected only
+var membershipOnlyCollector = world.CreateCollector(
     EntityMatcher.With.OfAll<PositionComponent>(),
     EntityCollectorFlag.None
-);
-
-// LazyAdd - newly matching entities won't appear in Collected until Flush() is called
-var lazyAddCollector = world.CreateCollector(
-    EntityMatcher.With.OfAll<PositionComponent>(),
-    EntityCollectorFlag.LazyAdd
-);
-
-// LazyRemove - entities won't be removed from Collected until Flush() is called
-var lazyRemoveCollector = world.CreateCollector(
-    EntityMatcher.With.OfAll<PositionComponent>(),
-    EntityCollectorFlag.LazyRemove
-);
-
-// Default (used when no flag is specified):
-// Lazy + LazyChange + RevisionAsChange + ChangedOnMatching
-var lazyCollector = world.CreateCollector(
-    EntityMatcher.With.OfAll<PositionComponent>()
-    // EntityCollectorFlag.Default is used by default
 );
 ```
 
 #### Change Tracking
 
-Collectors track matching/clashing in flush phases, while `Changed` timing depends on `LazyChange`:
+After `Flush()`, inspect the buffers from the completed phase:
 
 ```csharp
 var collector = world.CreateCollector(
@@ -389,14 +390,15 @@ foreach (var entityId in clashingEntities)
 }
 ```
 
-`Changed` behavior depends on collector flags:
+Flag reference:
 
-- `RevisionAsChange`: include entities whose component data changed (default includes this).
-- `ChangedOnMatching`: include entities that newly enter the collector (default includes this).
-- `ChangedOnClashing`: include entities that leave the collector (disabled by default, enable explicitly when needed).
-- `LazyChange`: defer updates to `Changed` until `Flush()`; when not enabled, `Changed` updates immediately on events.
+- `RevisionAsChange` — mirror component **data** revisions into `Changed` (included in `Default`).
+- `MatchAsChange` — mirror entities **entering** the collector into `Changed` (included in `Default`).
+- `ClashAsChange` — mirror entities **leaving** the collector into `Changed` (not in `Default`; `Clashing` always lists departures after `Flush()`).
+- `RelatedComponentOnly` — limit component-driven `Changed` entries to matcher-relevant types (included in `Default`).
+- `None` — do not mirror any category into `Changed`; structural membership is still available via `Matching` / `Clashing`.
 
-With `EntityCollectorFlag.Default`, `Changed` includes revision changes and newly matching entities, but not clashing entities, and becomes visible after `Flush()`.
+With `EntityCollectorFlag.Default`, treat `Changed` as the set of collected entities that need reprocessing after structural or match-relevant data updates. Entities that stop matching appear in `Clashing`, not `Changed`, unless you add `ClashAsChange`.
 
 #### Best Practices for Using Collectors
 
@@ -431,8 +433,9 @@ public void OnDestroy()
 ```
 
 4. **Choose appropriate flags** based on your use case:
-   - Use `Lazy` flag when you want to process all changes at once in a predictable manner
-   - Use `None` flag when you need immediate updates to the collection
+   - Call `Flush()` once per frame (or phase) to publish buffered membership and change lists
+   - Use `EntityCollectorFlag.None` when systems only need `Matching` / `Clashing` / `Collected`
+   - Add `ClashAsChange` when systems must react to entities leaving the collector via `Changed`
 
 
 ### 11. Complete Example

--- a/Test/EntityCollectorTestUnit.cs
+++ b/Test/EntityCollectorTestUnit.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using CoreECS;
 using CoreECS.Defines;
 using NUnit.Framework;
@@ -11,7 +9,7 @@ namespace TinyECS.Test
     [TestFixture]
     public class EntityCollectorTestUnit
     {
-        private World _world;
+        private World _world = null!;
         
         [SetUp]
         public void Setup()
@@ -25,252 +23,407 @@ namespace TinyECS.Test
         {
             _world?.Shutdown();
         }
-        
+
         [Test]
-        public void EntityCollector_DefaultBehavior_ImmediateCollection()
+        public void EntityCollectorFlag_Masks_RemainStable()
         {
-            // Arrange
+            Assert.AreEqual(0, (int)EntityCollectorFlag.None);
+            Assert.AreEqual(1 << 2, (int)EntityCollectorFlag.ChangedOnRevision);
+            Assert.AreEqual(1 << 3, (int)EntityCollectorFlag.ChangedOnMatching);
+            Assert.AreEqual(1 << 4, (int)EntityCollectorFlag.ChangedOnClashing);
+            Assert.AreEqual(1 << 6, (int)EntityCollectorFlag.ChangeMustBeRelatedComponent);
+            Assert.AreEqual(
+                EntityCollectorFlag.ChangedOnRevision
+                | EntityCollectorFlag.ChangedOnMatching
+                | EntityCollectorFlag.ChangeMustBeRelatedComponent,
+                EntityCollectorFlag.Default);
+        }
+
+        [Test]
+        public void EntityCollector_ExistingMatchingEntities_PublishOnFirstFlush()
+        {
             var entity1 = _world.CreateEntity();
             var entity2 = _world.CreateEntity();
             var entity3 = _world.CreateEntity();
-            
             entity1.CreateComponent<PositionComponent>();
             entity2.CreateComponent<PositionComponent>();
             entity2.CreateComponent<VelocityComponent>();
             entity3.CreateComponent<VelocityComponent>();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-            
-            // Act - No Change() needed for immediate behavior
-            var collectedEntities = new List<ulong>();
-            for (int i = 0; i < collector.Collected.Count; i++)
-            {
-                collectedEntities.Add(collector.Collected[i]);
-            }
-            
-            // Assert
-            Assert.AreEqual(2, collectedEntities.Count);
-            Assert.IsTrue(collectedEntities.Contains(entity1.EntityId));
-            Assert.IsTrue(collectedEntities.Contains(entity2.EntityId));
-            Assert.IsFalse(collectedEntities.Contains(entity3.EntityId));
-        }
-        
-        [Test]
-        public void EntityCollector_PhantomEntity_Exclusion()
-        {
-            // Arrange
-            var entity1 = _world.CreateEntity();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Lazy);
-            
-            entity1.CreateComponent<PositionComponent>();
-            entity1.DestroyComponent<PositionComponent>();
-            
+
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default);
+
+            AssertAllEmpty(collector);
+
             collector.Flush();
-            
-            // Assert
-            Assert.IsFalse(collector.Collected.Contains(entity1.EntityId));
-            Assert.IsFalse(collector.Clashing.Contains(entity1.EntityId));
-            Assert.IsFalse(collector.Matching.Contains(entity1.EntityId));
-        }
-        
-        
-        [Test]
-        public void EntityCollector_NonLazy_RealtimeMatchClash()
-        {
-            // Arrange
-            var entity1 = _world.CreateEntity();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-            
-            entity1.CreateComponent<PositionComponent>();
-            
-            // Assert
-            Assert.IsTrue(collector.Collected.Contains(entity1.EntityId));
-            Assert.IsFalse(collector.Clashing.Contains(entity1.EntityId));
-            Assert.IsTrue(collector.Matching.Contains(entity1.EntityId));
-            
-            entity1.DestroyComponent<PositionComponent>();
-            
-            // Assert
-            Assert.IsFalse(collector.Collected.Contains(entity1.EntityId));
-            Assert.IsTrue(collector.Clashing.Contains(entity1.EntityId));
-            Assert.IsFalse(collector.Matching.Contains(entity1.EntityId));
-            
-            collector.Flush();
-            
-            // Assert
-            Assert.IsFalse(collector.Collected.Contains(entity1.EntityId));
-            Assert.IsFalse(collector.Clashing.Contains(entity1.EntityId));
-            Assert.IsFalse(collector.Matching.Contains(entity1.EntityId));
-        }
-        
-        [Test]
-        public void EntityCollector_LazyAddBehavior_DelayedAddition()
-        {
-            // Arrange
-            var entity1 = _world.CreateEntity();
-            var entity2 = _world.CreateEntity();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.LazyAdd);
-            
-            // Act - Add components after collector creation
-            entity1.CreateComponent<PositionComponent>();
-            entity2.CreateComponent<PositionComponent>();
-            
-            // Before Change() - should not be in collected
-            var beforeChangeCollected = new List<ulong>();
-            for (int i = 0; i < collector.Collected.Count; i++)
-            {
-                beforeChangeCollected.Add(collector.Collected[i]);
-            }
-            
-            collector.Flush();
-            
-            // After Change() - should be in collected
-            var afterChangeCollected = new List<ulong>();
-            for (int i = 0; i < collector.Collected.Count; i++)
-            {
-                afterChangeCollected.Add(collector.Collected[i]);
-            }
-            
-            // Assert
-            Assert.AreEqual(0, beforeChangeCollected.Count, "Entities should not be collected before Change() with LazyAdd");
-            Assert.AreEqual(2, afterChangeCollected.Count, "Entities should be collected after Change() with LazyAdd");
-            Assert.IsTrue(afterChangeCollected.Contains(entity1.EntityId));
-            Assert.IsTrue(afterChangeCollected.Contains(entity2.EntityId));
-        }
-        
-        [Test]
-        public void EntityCollector_LazyRemoveBehavior_DelayedRemoval()
-        {
-            // Arrange
-            var entity1 = _world.CreateEntity();
-            var entity2 = _world.CreateEntity();
-            
-            entity1.CreateComponent<PositionComponent>();
-            entity2.CreateComponent<PositionComponent>();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.LazyRemove);
-            
-            // Act - Remove component
-            entity1.DestroyComponent(entity1.GetComponent<PositionComponent>());
-            
-            // Before Change() - should still be in collected
-            var beforeChangeCollected = new List<ulong>(collector.Collected);
-            
-            collector.Flush();
-            
-            // After Change() - should be removed from collected
-            var afterChangeCollected = new List<ulong>(collector.Collected);
-            
-            // Assert
-            Assert.AreEqual(2, beforeChangeCollected.Count, "Entities should still be collected before Change() with LazyRemove");
-            Assert.AreEqual(1, afterChangeCollected.Count, "Entity should be removed after Change() with LazyRemove");
-            Assert.IsFalse(afterChangeCollected.Contains(entity1.EntityId));
-            Assert.IsTrue(afterChangeCollected.Contains(entity2.EntityId));
-        }
-        
-        [Test]
-        public void EntityCollector_LazyBehavior_DelayedBothAddAndRemove()
-        {
-            // Arrange
-            var entity1 = _world.CreateEntity();
-            var entity2 = _world.CreateEntity();
-            var entity3 = _world.CreateEntity();
-            
-            entity1.CreateComponent<PositionComponent>();
-            entity2.CreateComponent<PositionComponent>();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Lazy);
-            
-            // Act - Add and remove components
-            entity1.DestroyComponent(entity1.GetComponent<PositionComponent>()); // Should be removed
-            entity3.CreateComponent<PositionComponent>(); // Should be added
-            
-            // Before Change()
-            var beforeChangeCollected = new List<ulong>(collector.Collected);
-            
-            collector.Flush();
-            
-            // After Change()
-            var afterChangeCollected = new List<ulong>(collector.Collected);
-            
-            // Assert
-            Assert.AreEqual(0, beforeChangeCollected.Count, "Original entities should be present before Change()");
-            Assert.AreEqual(2, afterChangeCollected.Count, "Only entity1 should not remain after Change()");
-            Assert.IsFalse(afterChangeCollected.Contains(entity1.EntityId)); // Should not be added yet due to LazyAdd
-            Assert.IsTrue(afterChangeCollected.Contains(entity2.EntityId));
-            Assert.IsTrue(afterChangeCollected.Contains(entity3.EntityId)); 
-        }
-        
-        [Test]
-        public void EntityCollector_MatchingAndClashingBuffers_TracksChanges()
-        {
-            // Arrange
-            var entity1 = _world.CreateEntity();
-            var entity2 = _world.CreateEntity();
-            
-            entity1.CreateComponent<PositionComponent>();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-            
-            // Act - Make changes
-            entity2.CreateComponent<PositionComponent>(); // Should be matching
-            entity1.DestroyComponent(entity1.GetComponent<PositionComponent>()); // Should be clashing
-            
-            var finalCollected = new List<ulong>(collector.Collected);
-            
-            collector.Flush();
-            
-            // Get matching and clashing entities after Change()
-            var matchingEntities = new List<ulong>(collector.Matching);
-            var clashingEntities = new List<ulong>(collector.Clashing);
-            
-            // Assert
-            Assert.AreEqual(1, matchingEntities.Count, "entity2 should be matching");
-            Assert.IsTrue(matchingEntities.Contains(entity2.EntityId));
-            
-            Assert.AreEqual(1, clashingEntities.Count, "entity1 should be clashing");
-            Assert.IsTrue(clashingEntities.Contains(entity1.EntityId));
-            
-            Assert.AreEqual(1, finalCollected.Count, "Only entity2 should be in final collection");
-            Assert.IsTrue(finalCollected.Contains(entity2.EntityId));
+
+            AssertOnly(collector.Matching, entity1.EntityId, entity2.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity1.EntityId, entity2.EntityId);
+            AssertOnly(collector.Changed, entity1.EntityId, entity2.EntityId);
         }
 
         [Test]
-        public void EntityCollector_DefaultFlags_IncludeMatchingAndRevisionInChanged()
+        public void EntityCollector_MatchingEntity_PublishesOnlyAfterFlush()
         {
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher);
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default);
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "pending matching entity must not be visible before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_ClashingEntity_PublishesOnlyAfterFlush()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+
+            entity.DestroyComponent<PositionComponent>();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Collected);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_RevisionChanges_PublishOnceAfterFlush()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default);
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            ref var firstWrite = ref entity.GetComponent<PositionComponent>().RW;
+            firstWrite.X = 1;
+            ref var secondWrite = ref entity.GetComponent<PositionComponent>().RW;
+            secondWrite.Y = 2;
+            ref var thirdWrite = ref entity.GetComponent<PositionComponent>().RW;
+            thirdWrite.X = 3;
+
+            beforeChange.AssertMatches(collector, "revision changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_MatchThenClashBeforeFirstFlush_DropsEntityFromAllBuffers()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<PositionComponent>();
+            entity.DestroyComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "transient entity must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertAllEmpty(collector);
+        }
+
+        [Test]
+        public void EntityCollector_EmptyFlush_ClearsPhaseBuffersAndKeepsCollected()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default);
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_ClashThenMatchBetweenFlushes_KeepsCollectedAndDedupsChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.DestroyComponent<PositionComponent>();
+            entity.CreateComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "membership bounce must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_MultipleEnterAndLeaveBetweenFlushes_UsesFinalStateAndDedupsChanged()
+        {
+            var entering = _world.CreateEntity();
+            var leaving = _world.CreateEntity();
+            leaving.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entering.CreateComponent<PositionComponent>();
+            entering.DestroyComponent<PositionComponent>();
+            entering.CreateComponent<PositionComponent>();
+
+            leaving.DestroyComponent<PositionComponent>();
+            leaving.CreateComponent<PositionComponent>();
+            leaving.DestroyComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "multiple membership changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entering.EntityId);
+            AssertOnly(collector.Clashing, leaving.EntityId);
+            AssertOnly(collector.Collected, entering.EntityId);
+            AssertOnly(collector.Changed, entering.EntityId, leaving.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_MixedEntityChangesBetweenFlushes_PublishesEachEntityInExpectedBuffer()
+        {
+            var entering = _world.CreateEntity();
+            var leaving = _world.CreateEntity();
+            var updating = _world.CreateEntity();
+            leaving.CreateComponent<PositionComponent>();
+            updating.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entering.CreateComponent<PositionComponent>();
+            leaving.DestroyComponent<PositionComponent>();
+            ref var writable = ref updating.GetComponent<PositionComponent>().RW;
+            writable.X = 10;
+
+            beforeChange.AssertMatches(collector, "mixed changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entering.EntityId);
+            AssertOnly(collector.Clashing, leaving.EntityId);
+            AssertOnly(collector.Collected, updating.EntityId, entering.EntityId);
+            AssertOnly(collector.Changed, entering.EntityId, leaving.EntityId, updating.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_NoneFlag_DoesNotMarkMembershipOrRevisionChanged()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.None);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
 
-            Assert.IsTrue(collector.Matching.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertEmpty(collector.Changed);
 
             collector.Flush();
-
-            var position = entity.GetComponent<PositionComponent>();
-            ref var writable = ref position.RW;
-            writable.X = 12;
-
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 5;
             collector.Flush();
 
-            Assert.AreEqual(0, collector.Matching.Count);
-            Assert.AreEqual(0, collector.Clashing.Count);
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertEmpty(collector.Changed);
+
+            entity.DestroyComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Collected);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_ChangedOnMatching_OnlyMarksMatchingEntitiesChanged()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.ChangedOnMatching);
+
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+
+            collector.Flush();
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 1;
+            collector.Flush();
+            AssertEmpty(collector.Changed);
+
+            entity.DestroyComponent<PositionComponent>();
+            collector.Flush();
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_ChangedOnClashing_OnlyMarksClashingEntitiesChanged()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.ChangedOnClashing);
+
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Changed);
+
+            collector.Flush();
+            entity.DestroyComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_ChangedOnRevision_OnlyMarksRevisionChangesChanged()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.ChangedOnRevision);
+
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Changed);
+
+            collector.Flush();
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 7;
+            collector.Flush();
+
+            AssertOnly(collector.Changed, entity.EntityId);
+
+            collector.Flush();
+            entity.DestroyComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_ChangedOnRevisionWithRelatedComponentFlag_FiltersIrrelevantRevisions()
+        {
+            const EntityCollectorFlag flag =
+                EntityCollectorFlag.ChangedOnRevision
+                | EntityCollectorFlag.ChangeMustBeRelatedComponent;
+
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            entity.CreateComponent<VelocityComponent>();
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
+            collector.Flush();
+            collector.Flush();
+
+            ref var velocity = ref entity.GetComponent<VelocityComponent>().RW;
+            velocity.X = 1;
+            collector.Flush();
+            AssertEmpty(collector.Changed);
+
+            ref var position = ref entity.GetComponent<PositionComponent>().RW;
+            position.X = 2;
+            collector.Flush();
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_DefaultFlag_TracksMatchingAndRelevantRevisionOnly()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.Default);
+
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
+
+            collector.Flush();
+            entity.CreateComponent<VelocityComponent>();
+            collector.Flush();
+            AssertEmpty(collector.Changed);
+
+            ref var position = ref entity.GetComponent<PositionComponent>().RW;
+            position.X = 3;
+            collector.Flush();
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
@@ -281,25 +434,21 @@ namespace TinyECS.Test
             var collector = _world.CreateCollector(matcher);
 
             entity.CreateComponent<PositionComponent>();
-            var position = entity.GetComponent<PositionComponent>();
-            ref var writable = ref position.RW;
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
             writable.X = 7;
 
             collector.Flush();
 
-            Assert.AreEqual(1, collector.Matching.Count);
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Matching.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_DefaultFlags_ExcludeClashingFromChanged()
         {
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>());
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
@@ -308,8 +457,8 @@ namespace TinyECS.Test
             entity.DestroyComponent<PositionComponent>();
             collector.Flush();
 
-            Assert.IsTrue(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Changed);
         }
 
         [Test]
@@ -317,73 +466,25 @@ namespace TinyECS.Test
         {
             var entity = _world.CreateEntity();
             entity.CreateComponent<PositionComponent>();
-
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             var collector = _world.CreateCollector(
-                matcher,
-                EntityCollectorFlag.None | EntityCollectorFlag.ChangedOnClashing | EntityCollectorFlag.LazyChange);
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.ChangedOnClashing);
 
             collector.Flush();
             entity.DestroyComponent<PositionComponent>();
             collector.Flush();
 
-            Assert.IsTrue(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-        }
-
-        [Test]
-        public void EntityCollector_ChangedOnRevisionDisabled_IgnoresDataUpdates()
-        {
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-            collector.Flush();
-
-            var position = entity.GetComponent<PositionComponent>();
-            ref var writable = ref position.RW;
-            writable.X = 5;
-
-            collector.Flush();
-
-            Assert.AreEqual(0, collector.Matching.Count);
-            Assert.AreEqual(0, collector.Clashing.Count);
-            Assert.AreEqual(0, collector.Changed.Count);
-        }
-
-        [Test]
-        public void EntityCollector_Changed_DeduplicatesMultipleRevisions()
-        {
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(
-                matcher,
-                EntityCollectorFlag.None | EntityCollectorFlag.ChangedOnRevision | EntityCollectorFlag.LazyChange);
-
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-            collector.Flush();
-
-            var position = entity.GetComponent<PositionComponent>();
-            ref var firstWrite = ref position.RW;
-            firstWrite.X = 1;
-            ref var secondWrite = ref position.RW;
-            secondWrite.Y = 2;
-
-            collector.Flush();
-
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_StructureChangeWhileStillMatched_IncludesChanged()
         {
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None | EntityCollectorFlag.LazyChange);
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.None);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
@@ -392,179 +493,97 @@ namespace TinyECS.Test
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
 
-            Assert.AreEqual(0, collector.Matching.Count);
-            Assert.AreEqual(0, collector.Clashing.Count);
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
-        public void EntityCollector_LazyChange_DefersRevisionChangedUntilFlush()
+        public void EntityCollector_RevisionChanged_IsVisibleOnlyAfterFlush()
         {
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             var collector = _world.CreateCollector(
-                matcher,
-                EntityCollectorFlag.None | EntityCollectorFlag.ChangedOnRevision | EntityCollectorFlag.LazyChange);
-
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.ChangedOnRevision);
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
 
-            var position = entity.GetComponent<PositionComponent>();
-            ref var writable = ref position.RW;
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
             writable.X = 99;
 
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
+            beforeChange.AssertMatches(collector, "revision change must not be visible before Flush");
+
             collector.Flush();
 
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
-        public void EntityCollector_NonLazyChange_RevisionChangedVisibleImmediately()
+        public void EntityCollector_Flush_ProcessesPendingChanges()
         {
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(
-                matcher,
-                EntityCollectorFlag.None | EntityCollectorFlag.ChangedOnRevision);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>());
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
-            collector.Flush();
 
-            var position = entity.GetComponent<PositionComponent>();
-            ref var writable = ref position.RW;
-            writable.X = 42;
-
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-        }
-
-        [Test]
-        public void EntityCollector_NonLazyChange_FlushWithoutNewChanges_ClearsChanged()
-        {
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(
-                matcher,
-                EntityCollectorFlag.None | EntityCollectorFlag.ChangedOnRevision);
-
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-            collector.Flush();
-
-            var position = entity.GetComponent<PositionComponent>();
-            ref var writable = ref position.RW;
-            writable.X = 100;
-
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            collector.Flush();
-
-            Assert.AreEqual(0, collector.Changed.Count);
-        }
-
-        [Test]
-        public void EntityCollector_Change_DelegatesToFlush()
-        {
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher);
-
-            entity.CreateComponent<PositionComponent>();
-
-#pragma warning disable CS0618
-            collector.Flush();
-#pragma warning restore CS0618
-
-            Assert.IsTrue(collector.Matching.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
         
         [Test]
         public void EntityCollector_Dispose_ClearsAllBuffers()
         {
-            // Arrange
             var entity1 = _world.CreateEntity();
             var entity2 = _world.CreateEntity();
-            
             entity1.CreateComponent<PositionComponent>();
             entity2.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>());
+            collector.Flush();
             
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-            
-            // Act
             collector.Dispose();
             
-            // Assert - All buffers should be empty
-            Assert.AreEqual(0, collector.Collected.Count);
-            Assert.AreEqual(0, collector.Matching.Count);
-            Assert.AreEqual(0, collector.Clashing.Count);
+            AssertAllEmpty(collector);
         }
         
         [Test]
         public void EntityCollector_MultipleChanges_ComplexScenario()
         {
-            // Arrange
             var entities = new List<Entity>();
             for (int i = 0; i < 5; i++)
             {
                 entities.Add(_world.CreateEntity());
             }
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>());
             
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher);
-            
-            // Act - Complex sequence of changes
             entities[0].CreateComponent<PositionComponent>();
             entities[1].CreateComponent<PositionComponent>();
             entities[2].CreateComponent<PositionComponent>();
-            
             collector.Flush();
             
-            // Verify first batch
-            var firstBatch = new List<ulong>(collector.Collected);
-            Assert.That(firstBatch.Count, Is.EqualTo(3));
+            AssertOnly(collector.Collected, entities[0].EntityId, entities[1].EntityId, entities[2].EntityId);
             
-            // More changes
-            entities[0].DestroyComponent(entities[0].GetComponent<PositionComponent>());
+            entities[0].DestroyComponent<PositionComponent>();
             entities[3].CreateComponent<PositionComponent>();
             entities[4].CreateComponent<PositionComponent>();
-            
             collector.Flush();
             
-            // Verify second batch
-            var secondBatch = new List<ulong>(collector.Collected);
-            Assert.That(secondBatch.Count, Is.EqualTo(4));
-            
-            Assert.IsFalse(secondBatch.Contains(entities[0].EntityId));
-            Assert.IsTrue(secondBatch.Contains(entities[1].EntityId));
-            Assert.IsTrue(secondBatch.Contains(entities[2].EntityId));
-            Assert.IsTrue(secondBatch.Contains(entities[3].EntityId));
-            Assert.IsTrue(secondBatch.Contains(entities[4].EntityId));
+            AssertOnly(collector.Collected, entities[1].EntityId, entities[2].EntityId, entities[3].EntityId, entities[4].EntityId);
         }
         
         [Test]
         public void EntityCollector_ForEachSafety_DoesNotUseForeach()
         {
-            // This test verifies that we don't use foreach when iterating Collected
-            // as requested in the requirements for safety reasons
-            
-            // Arrange
             var entity1 = _world.CreateEntity();
             var entity2 = _world.CreateEntity();
-            
             entity1.CreateComponent<PositionComponent>();
             entity2.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>());
+            collector.Flush();
             
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-            
-            // Act & Assert - Use for loop instead of foreach as specified
             var collectedCount = 0;
             for (int i = 0; i < collector.Collected.Count; i++)
             {
@@ -572,10 +591,8 @@ namespace TinyECS.Test
                 var entityId = collector.Collected[i];
                 Assert.IsTrue(entityId == entity1.EntityId || entityId == entity2.EntityId);
             }
-            
             Assert.AreEqual(2, collectedCount);
             
-            // Also test with while loop as an alternative
             var whileCount = 0;
             var index = 0;
             while (index < collector.Collected.Count)
@@ -583,473 +600,284 @@ namespace TinyECS.Test
                 whileCount++;
                 index++;
             }
-            
             Assert.AreEqual(2, whileCount);
         }
         
         [Test]
         public void EntityCollector_PropertyAccess_Matcher()
         {
-            // Test accessing the Matcher property of a collector
             var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
             
-            // Assert
             Assert.IsNotNull(collector.Matcher);
             Assert.AreEqual(matcher.EntityMask, collector.Matcher.EntityMask);
         }
         
         [Test]
-        public void EntityCollector_FlagCombinations_LazyAddOnly()
+        public void EntityCollector_BufferManagement_ClearAfterFlush()
         {
-            // Test EntityCollectorFlag.LazyAdd flag behavior specifically
             var entity1 = _world.CreateEntity();
             var entity2 = _world.CreateEntity();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.LazyAdd);
-            
-            // Act - Add components after collector creation
             entity1.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>(),
+                EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            
             entity2.CreateComponent<PositionComponent>();
+            entity1.DestroyComponent<PositionComponent>();
+            collector.Flush();
             
-            // Before Change() - should not be in collected due to LazyAdd
-            var beforeChangeCount = collector.Collected.Count;
+            AssertOnly(collector.Matching, entity2.EntityId);
+            AssertOnly(collector.Clashing, entity1.EntityId);
             
             collector.Flush();
             
-            // After Change() - should be in collected
-            var afterChangeCount = collector.Collected.Count;
-            
-            // Assert
-            Assert.AreEqual(0, beforeChangeCount, "Should not collect entities before Change() with LazyAdd flag");
-            Assert.AreEqual(2, afterChangeCount, "Should collect entities after Change() with LazyAdd flag");
-        }
-        
-        [Test]
-        public void EntityCollector_FlagCombinations_LazyRemoveOnly()
-        {
-            // Test EntityCollectorFlag.LazyRemove flag behavior specifically
-            var entity1 = _world.CreateEntity();
-            var entity2 = _world.CreateEntity();
-            
-            entity1.CreateComponent<PositionComponent>();
-            entity2.CreateComponent<PositionComponent>();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.LazyRemove);
-            
-            // Act - Remove component
-            entity1.DestroyComponent(entity1.GetComponent<PositionComponent>());
-            
-            // Before Change() - should still be in collected due to LazyRemove
-            var beforeChangeCount = collector.Collected.Count;
-            
-            collector.Change();
-            
-            // After Change() - should be removed from collected
-            var afterChangeCount = collector.Collected.Count;
-            
-            // Assert
-            Assert.AreEqual(2, beforeChangeCount, "Should still contain entities before Change() with LazyRemove flag");
-            Assert.AreEqual(1, afterChangeCount, "Should remove entity after Change() with LazyRemove flag");
-        }
-        
-        [Test]
-        public void EntityCollector_BufferManagement_ClearAfterChange()
-        {
-            // Test that matching and clashing buffers are cleared after Change() is called
-            var entity1 = _world.CreateEntity();
-            var entity2 = _world.CreateEntity();
-            
-            entity1.CreateComponent<PositionComponent>();
-            
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.None);
-            
-            // Act - Make changes that affect matching/clashing
-            entity2.CreateComponent<PositionComponent>(); // Should be matching
-            entity1.DestroyComponent(entity1.GetComponent<PositionComponent>()); // Should be clashing
-            
-            collector.Flush(); // Process the changes
-            
-            // Verify buffers have the expected entities
-            var matchingBeforeSecondChange = new List<ulong>(collector.Matching);
-            var clashingBeforeSecondChange = new List<ulong>(collector.Clashing);
-            
-            // Call Change() again without any actual changes
-            collector.Flush();
-            
-            var matchingAfterSecondChange = new List<ulong>(collector.Matching);
-            var clashingAfterSecondChange = new List<ulong>(collector.Clashing);
-            
-            // Assert
-            Assert.AreEqual(1, matchingBeforeSecondChange.Count, "Should have 1 matching entity");
-            Assert.AreEqual(1, clashingBeforeSecondChange.Count, "Should have 1 clashing entity");
-            
-            Assert.AreEqual(0, matchingAfterSecondChange.Count, "Matching buffer should be cleared after Change()");
-            Assert.AreEqual(0, clashingAfterSecondChange.Count, "Clashing buffer should be cleared after Change()");
-        }
-        
-        [Test]
-        public void EntityCollector_ChangeMethod_ProcessesChanges()
-        {
-            // Test that Change() method properly processes changes
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
-            
-            // Initially no entities should match
-            Assert.AreEqual(0, collector.Changed.Count);
-            Assert.AreEqual(0, collector.Collected.Count);
-            
-            // Add component that makes entity match
-            entity.CreateComponent<PositionComponent>();
-            
-            // Process changes
-            collector.Flush();
-            
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.AreEqual(1, collector.Collected.Count);
-
-            entity.DestroyComponent<PositionComponent>();
-            entity.CreateComponent<PositionComponent>();
-            
-            // Process changes
-            collector.Flush();
-            
-            // Now should be collected
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.AreEqual(1, collector.Collected.Count);
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_AddIrrelevantComponent_DoesNotMarkChanged()
         {
-            // With ChangeComponent enabled (Default), adding a component that is not
-            // in the matcher's all/any/none sets must not pollute Changed while the
-            // entity is still a member of the collector.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
 
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertEmpty(collector.Changed);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_ModifyIrrelevantComponent_DoesNotMarkChanged()
         {
-            // Revising a component that is not part of the matcher must not
-            // surface the entity in Changed when ChangeComponent is enabled.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             ref var rw = ref entity.GetComponent<VelocityComponent>().RW;
             rw.X = 42;
             collector.Flush();
 
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertEmpty(collector.Changed);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_WithoutChangeComponent_AddIrrelevantComponent_MarksChanged()
         {
-            // Without the ChangeComponent flag the relevance gate is bypassed,
-            // preserving the pre-fix behavior where any structural change of a
-            // collected entity surfaces it in Changed.
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.Lazy
-                | EntityCollectorFlag.LazyChange
-                | EntityCollectorFlag.ChangedOnMatching
+                EntityCollectorFlag.ChangedOnMatching
                 | EntityCollectorFlag.ChangedOnRevision;
 
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, flag);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
 
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_WithoutChangeComponent_ModifyIrrelevantComponent_MarksChanged()
         {
-            // Same contrast as above, but along the revision path.
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.Lazy
-                | EntityCollectorFlag.LazyChange
-                | EntityCollectorFlag.ChangedOnMatching
+                EntityCollectorFlag.ChangedOnMatching
                 | EntityCollectorFlag.ChangedOnRevision;
 
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, flag);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             ref var rw = ref entity.GetComponent<VelocityComponent>().RW;
             rw.X = 7;
             collector.Flush();
 
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_ModifyRelevantComponent_StillMarksChanged()
         {
-            // The relevance gate must not suppress changes on components that
-            // belong to the matcher's all/any/none sets.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             ref var rw = ref entity.GetComponent<PositionComponent>().RW;
             rw.X = 12;
             collector.Flush();
 
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_RemoveRelevantComponent_MarksClashingAndChanged()
         {
-            // ChangedOnClashing combined with ChangeComponent: removing a relevant
-            // component flips membership, hitting the clash branch which sits
-            // outside the relevance gate. The entity must enter both Clashing
-            // and Changed.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             var collector = _world.CreateCollector(
-                matcher,
+                EntityMatcher.With.OfAll<PositionComponent>(),
                 EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             entity.DestroyComponent<PositionComponent>();
             collector.Flush();
 
-            Assert.IsFalse(collector.Collected.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertEmpty(collector.Collected);
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_RemoveIrrelevantComponent_DoesNotClashOrChange()
         {
-            // Removing an irrelevant component leaves membership intact, so the
-            // relevance gate must filter the entity out of Changed and the
-            // clash bookkeeping must remain untouched.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             var collector = _world.CreateCollector(
-                matcher,
+                EntityMatcher.With.OfAll<PositionComponent>(),
                 EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             entity.DestroyComponent<VelocityComponent>();
             collector.Flush();
 
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertEmpty(collector.Changed);
         }
 
         [Test]
         public void EntityCollector_WithoutChangeComponent_RemoveIrrelevantComponent_MarksChanged()
         {
-            // Contrast for the clash configuration: without ChangeComponent the
-            // irrelevant removal still slips into Changed via the
-            // membership-unchanged branch, while never being treated as a clash.
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.Lazy
-                | EntityCollectorFlag.LazyChange
-                | EntityCollectorFlag.ChangedOnMatching
+                EntityCollectorFlag.ChangedOnMatching
                 | EntityCollectorFlag.ChangedOnRevision
                 | EntityCollectorFlag.ChangedOnClashing;
 
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, flag);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             entity.DestroyComponent<VelocityComponent>();
             collector.Flush();
 
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_EmptyMatcher_DoesNotDropChanges()
         {
-            // Regression for the empty-matcher edge case: with Default flags
-            // (ChangeComponent enabled) and a matcher that has no
-            // all/any/none conditions, every structural and revision change
-            // on a collected entity must still surface in Changed. If the
-            // shortcut in IsRelevantComponent ever regresses, the relevance
-            // gate would silently swallow all these notifications.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With;
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
+            var collector = _world.CreateCollector(EntityMatcher.With, EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
 
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
-
             ref var rwPos = ref entity.GetComponent<PositionComponent>().RW;
             rwPos.X = 7;
             collector.Flush();
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
 
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
-
             entity.CreateComponent<VelocityComponent>();
             collector.Flush();
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
 
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
-
             ref var rwVel = ref entity.GetComponent<VelocityComponent>().RW;
             rwVel.X = 11;
             collector.Flush();
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_MixRelevantAndIrrelevant_BetweenFlushes_DedupsToRelevantOnly()
         {
-            // Multiple events of mixed relevance accumulate between two
-            // flushes. The relevance gate must filter the irrelevant ones
-            // while letting the relevant revisions through, and the back
-            // buffer must collapse the multiple relevant revisions into a
-            // single Changed entry.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             ref var rwPosA = ref entity.GetComponent<PositionComponent>().RW;
             rwPosA.X = 1;
-
             entity.CreateComponent<VelocityComponent>();
-
             ref var rwVel = ref entity.GetComponent<VelocityComponent>().RW;
             rwVel.X = 2;
-
             ref var rwPosB = ref entity.GetComponent<PositionComponent>().RW;
             rwPosB.Y = 3;
-
             collector.Flush();
 
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_OnlyIrrelevant_BetweenFlushes_KeepsChangedEmpty()
         {
-            // Only irrelevant events occur between two flushes. With
-            // ChangeComponent enabled every notification is dropped and
-            // Changed must remain empty, while the entity is still
-            // considered a member of the collector.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             entity.CreateComponent<VelocityComponent>();
-
             ref var rwVel1 = ref entity.GetComponent<VelocityComponent>().RW;
             rwVel1.X = 1;
-
             ref var rwVel2 = ref entity.GetComponent<VelocityComponent>().RW;
             rwVel2.Y = 2;
-
             collector.Flush();
 
-            Assert.AreEqual(0, collector.Changed.Count);
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
+            AssertEmpty(collector.Changed);
+            AssertOnly(collector.Collected, entity.EntityId);
         }
 
         [Test]
         public void EntityCollector_ChangeComponent_MultipleRelevantComponents_BetweenFlushes_DedupChanged()
         {
-            // Two relevant signals on the same entity in the same phase:
-            // one revision branch (CompA mutation) and one membership
-            // flip branch (adding CompB which is in the OfNone set). Both
-            // call MarkChanged via different code paths and the back
-            // buffer must deduplicate them into a single Changed entry.
             var entity = _world.CreateEntity();
             var matcher = EntityMatcher.With
                 .OfAll<PositionComponent>()
@@ -1061,105 +889,27 @@ namespace TinyECS.Test
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
 
             ref var rwPos = ref entity.GetComponent<PositionComponent>().RW;
             rwPos.X = 5;
-
             entity.CreateComponent<VelocityComponent>();
-
             collector.Flush();
 
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Collected.Contains(entity.EntityId));
+            AssertOnly(collector.Changed, entity.EntityId);
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Collected);
         }
 
         [Test]
-        public void EntityCollector_NonLazyChange_AccumulatesChangedBetweenFlushes()
+        public void EntityCollector_AlternatingModifyAndFlush_EachFlushExposesOneChange()
         {
-            // Realtime mode (no LazyChange): consecutive revisions on the
-            // relevant component must be immediately visible in Changed,
-            // be deduplicated to a single entry, and then be cleared by
-            // the next Flush.
             var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.ChangedOnRevision);
+            var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), EntityCollectorFlag.Default);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
-            Assert.AreEqual(0, collector.Changed.Count);
-
-            ref var rwFirst = ref entity.GetComponent<PositionComponent>().RW;
-            rwFirst.X = 1;
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-
-            ref var rwSecond = ref entity.GetComponent<PositionComponent>().RW;
-            rwSecond.X = 2;
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-
-            ref var rwThird = ref entity.GetComponent<PositionComponent>().RW;
-            rwThird.Y = 3;
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-
-            collector.Flush();
-
-            Assert.AreEqual(0, collector.Changed.Count);
-        }
-
-        [Test]
-        public void EntityCollector_ChangeComponent_BounceMembership_BetweenFlushes_LeavesConsistentState()
-        {
-            // The same entity leaves and re-enters the collector in the
-            // same phase. The CHANGE_MATCHING / CHANGE_CLASHING back
-            // buffers must converge to "still a member" and Changed must
-            // hold a single deduplicated entry produced by the match and
-            // clash signals combined.
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(
-                matcher,
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
-
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-            collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
-
-            entity.DestroyComponent<PositionComponent>();
-            entity.CreateComponent<PositionComponent>();
-
-            collector.Flush();
-
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Clashing.Contains(entity.EntityId));
-            Assert.IsFalse(collector.Matching.Contains(entity.EntityId));
-            Assert.AreEqual(1, collector.Changed.Count);
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-        }
-
-        [Test]
-        public void EntityCollector_LazyChange_AlternatingModifyAndFlush_EachFlushExposesOneChange()
-        {
-            // ABABAB loop with LazyChange enabled: each modify enqueues
-            // E into the back buffer, and the following Flush swaps it
-            // into the front Changed buffer. Across many iterations
-            // Changed must always show exactly one entry (E from the
-            // immediately preceding phase). When the loop ends without
-            // a modify, Changed must drain to empty within one Flush.
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.Default);
-
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-            collector.Flush();
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
+            AssertEmpty(collector.Changed);
 
             for (var i = 0; i < 4; i++)
             {
@@ -1168,49 +918,70 @@ namespace TinyECS.Test
 
                 collector.Flush();
 
-                Assert.AreEqual(1, collector.Changed.Count, $"iteration {i}");
-                Assert.IsTrue(collector.Changed.Contains(entity.EntityId), $"iteration {i}");
+                AssertOnly(collector.Changed, entity.EntityId);
             }
 
             collector.Flush();
-            Assert.AreEqual(0, collector.Changed.Count);
-
-            collector.Flush();
-            Assert.AreEqual(0, collector.Changed.Count);
+            AssertEmpty(collector.Changed);
         }
 
-        [Test]
-        public void EntityCollector_NonLazyChange_AlternatingModifyAndFlush_EachFlushClearsChanged()
+        private static void AssertAllEmpty(IEntityCollector collector)
         {
-            // ABABAB loop without LazyChange (realtime). Each modify
-            // makes E visible in Changed immediately, and the following
-            // Flush clears the realtime Changed buffer at the end of the
-            // phase. Across iterations this contract must hold without
-            // any cross-phase leakage.
-            var entity = _world.CreateEntity();
-            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
-            var collector = _world.CreateCollector(matcher, EntityCollectorFlag.ChangedOnRevision);
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertEmpty(collector.Collected);
+            AssertEmpty(collector.Changed);
+        }
 
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-            collector.Flush();
-            Assert.AreEqual(0, collector.Changed.Count);
+        private static void AssertEmpty(IReadOnlyList<ulong> actual)
+        {
+            Assert.AreEqual(0, actual.Count);
+        }
 
-            for (var i = 0; i < 4; i++)
+        private static void AssertOnly(IReadOnlyList<ulong> actual, params ulong[] expectedIds)
+        {
+            Assert.AreEqual(expectedIds.Length, actual.Count);
+            for (var i = 0; i < expectedIds.Length; i++)
             {
-                ref var rw = ref entity.GetComponent<PositionComponent>().RW;
-                rw.X = i;
-
-                Assert.AreEqual(1, collector.Changed.Count, $"iteration {i} before flush");
-                Assert.IsTrue(collector.Changed.Contains(entity.EntityId), $"iteration {i} before flush");
-
-                collector.Flush();
-
-                Assert.AreEqual(0, collector.Changed.Count, $"iteration {i} after flush");
+                AssertContainsOnce(actual, expectedIds[i]);
             }
         }
 
-        // Test components (same as other test files)
+        private static void AssertContainsOnce(IReadOnlyList<ulong> actual, ulong entityId)
+        {
+            var count = 0;
+            for (var i = 0; i < actual.Count; i++)
+            {
+                if (actual[i] == entityId)
+                    count += 1;
+            }
+            Assert.AreEqual(1, count);
+        }
+
+        private sealed class CollectorSnapshot
+        {
+            private readonly List<ulong> m_collected;
+            private readonly List<ulong> m_matching;
+            private readonly List<ulong> m_clashing;
+            private readonly List<ulong> m_changed;
+
+            public CollectorSnapshot(IEntityCollector collector)
+            {
+                m_collected = new List<ulong>(collector.Collected);
+                m_matching = new List<ulong>(collector.Matching);
+                m_clashing = new List<ulong>(collector.Clashing);
+                m_changed = new List<ulong>(collector.Changed);
+            }
+
+            public void AssertMatches(IEntityCollector collector, string message)
+            {
+                CollectionAssert.AreEqual(m_collected, new List<ulong>(collector.Collected), message);
+                CollectionAssert.AreEqual(m_matching, new List<ulong>(collector.Matching), message);
+                CollectionAssert.AreEqual(m_clashing, new List<ulong>(collector.Clashing), message);
+                CollectionAssert.AreEqual(m_changed, new List<ulong>(collector.Changed), message);
+            }
+        }
+
         private struct PositionComponent : IComponent<PositionComponent>
         {
             public float X;
@@ -1221,11 +992,6 @@ namespace TinyECS.Test
         {
             public float X;
             public float Y;
-        }
-        
-        private struct HealthComponent : IComponent<HealthComponent>
-        {
-            public float Value;
         }
     }
 }

--- a/Test/EntityCollectorTestUnit.cs
+++ b/Test/EntityCollectorTestUnit.cs
@@ -28,10 +28,10 @@ namespace TinyECS.Test
         public void EntityCollectorFlag_Masks_RemainStable()
         {
             Assert.AreEqual(0, (int)EntityCollectorFlag.None);
-            Assert.AreEqual(1 << 2, (int)EntityCollectorFlag.RevisionAsChange);
-            Assert.AreEqual(1 << 3, (int)EntityCollectorFlag.MatchAsChange);
-            Assert.AreEqual(1 << 4, (int)EntityCollectorFlag.ClashAsChange);
-            Assert.AreEqual(1 << 6, (int)EntityCollectorFlag.RelatedComponentOnly);
+            Assert.AreEqual(1 << 0, (int)EntityCollectorFlag.RevisionAsChange);
+            Assert.AreEqual(1 << 1, (int)EntityCollectorFlag.MatchAsChange);
+            Assert.AreEqual(1 << 2, (int)EntityCollectorFlag.ClashAsChange);
+            Assert.AreEqual(1 << 3, (int)EntityCollectorFlag.RelatedComponentOnly);
             Assert.AreEqual(
                 EntityCollectorFlag.RevisionAsChange
                 | EntityCollectorFlag.MatchAsChange

--- a/Test/EntityCollectorTestUnit.cs
+++ b/Test/EntityCollectorTestUnit.cs
@@ -149,7 +149,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.None);
             var beforeChange = new CollectorSnapshot(collector);
 
             entity.CreateComponent<PositionComponent>();
@@ -199,7 +199,7 @@ namespace TinyECS.Test
 
             collector.Flush();
 
-            AssertEmpty(collector.Matching);
+            AssertOnly(collector.Matching, entity.EntityId);
             AssertEmpty(collector.Clashing);
             AssertOnly(collector.Collected, entity.EntityId);
             AssertOnly(collector.Changed, entity.EntityId);

--- a/Test/EntityCollectorTestUnit.cs
+++ b/Test/EntityCollectorTestUnit.cs
@@ -28,14 +28,14 @@ namespace TinyECS.Test
         public void EntityCollectorFlag_Masks_RemainStable()
         {
             Assert.AreEqual(0, (int)EntityCollectorFlag.None);
-            Assert.AreEqual(1 << 2, (int)EntityCollectorFlag.ChangedOnRevision);
-            Assert.AreEqual(1 << 3, (int)EntityCollectorFlag.ChangedOnMatching);
-            Assert.AreEqual(1 << 4, (int)EntityCollectorFlag.ChangedOnClashing);
-            Assert.AreEqual(1 << 6, (int)EntityCollectorFlag.ChangeMustBeRelatedComponent);
+            Assert.AreEqual(1 << 2, (int)EntityCollectorFlag.RevisionAsChange);
+            Assert.AreEqual(1 << 3, (int)EntityCollectorFlag.MatchAsChange);
+            Assert.AreEqual(1 << 4, (int)EntityCollectorFlag.ClashAsChange);
+            Assert.AreEqual(1 << 6, (int)EntityCollectorFlag.RelatedComponentOnly);
             Assert.AreEqual(
-                EntityCollectorFlag.ChangedOnRevision
-                | EntityCollectorFlag.ChangedOnMatching
-                | EntityCollectorFlag.ChangeMustBeRelatedComponent,
+                EntityCollectorFlag.RevisionAsChange
+                | EntityCollectorFlag.MatchAsChange
+                | EntityCollectorFlag.RelatedComponentOnly,
                 EntityCollectorFlag.Default);
         }
 
@@ -92,7 +92,7 @@ namespace TinyECS.Test
             entity.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
 
             AssertOnly(collector.Matching, entity.EntityId);
@@ -187,7 +187,7 @@ namespace TinyECS.Test
             entity.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -213,7 +213,7 @@ namespace TinyECS.Test
             leaving.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -246,7 +246,7 @@ namespace TinyECS.Test
             updating.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -304,7 +304,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnMatching);
+                EntityCollectorFlag.MatchAsChange);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
@@ -330,7 +330,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.ClashAsChange);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
@@ -352,7 +352,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnRevision);
+                EntityCollectorFlag.RevisionAsChange);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
@@ -379,8 +379,8 @@ namespace TinyECS.Test
         public void EntityCollector_ChangedOnRevisionWithRelatedComponentFlag_FiltersIrrelevantRevisions()
         {
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.ChangedOnRevision
-                | EntityCollectorFlag.ChangeMustBeRelatedComponent;
+                EntityCollectorFlag.RevisionAsChange
+                | EntityCollectorFlag.RelatedComponentOnly;
 
             var entity = _world.CreateEntity();
             entity.CreateComponent<PositionComponent>();
@@ -468,7 +468,7 @@ namespace TinyECS.Test
             entity.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.ClashAsChange);
 
             collector.Flush();
             entity.DestroyComponent<PositionComponent>();
@@ -504,7 +504,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnRevision);
+                EntityCollectorFlag.RevisionAsChange);
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
             collector.Flush();
@@ -621,7 +621,7 @@ namespace TinyECS.Test
             entity1.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             
@@ -678,8 +678,8 @@ namespace TinyECS.Test
         public void EntityCollector_WithoutChangeComponent_AddIrrelevantComponent_MarksChanged()
         {
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.ChangedOnMatching
-                | EntityCollectorFlag.ChangedOnRevision;
+                EntityCollectorFlag.MatchAsChange
+                | EntityCollectorFlag.RevisionAsChange;
 
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
@@ -699,8 +699,8 @@ namespace TinyECS.Test
         public void EntityCollector_WithoutChangeComponent_ModifyIrrelevantComponent_MarksChanged()
         {
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.ChangedOnMatching
-                | EntityCollectorFlag.ChangedOnRevision;
+                EntityCollectorFlag.MatchAsChange
+                | EntityCollectorFlag.RevisionAsChange;
 
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
@@ -742,7 +742,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
@@ -763,7 +763,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
 
             entity.CreateComponent<PositionComponent>();
             entity.CreateComponent<VelocityComponent>();
@@ -782,9 +782,9 @@ namespace TinyECS.Test
         public void EntityCollector_WithoutChangeComponent_RemoveIrrelevantComponent_MarksChanged()
         {
             const EntityCollectorFlag flag =
-                EntityCollectorFlag.ChangedOnMatching
-                | EntityCollectorFlag.ChangedOnRevision
-                | EntityCollectorFlag.ChangedOnClashing;
+                EntityCollectorFlag.MatchAsChange
+                | EntityCollectorFlag.RevisionAsChange
+                | EntityCollectorFlag.ClashAsChange;
 
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(EntityMatcher.With.OfAll<PositionComponent>(), flag);
@@ -884,7 +884,7 @@ namespace TinyECS.Test
                 .OfNone<VelocityComponent>();
             var collector = _world.CreateCollector(
                 matcher,
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
 
             entity.CreateComponent<PositionComponent>();
             collector.Flush();
@@ -1025,7 +1025,7 @@ namespace TinyECS.Test
             clashEntity.CreateComponent<PositionComponent>();
             var clashCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             clashCollector.Flush();
             clashCollector.Flush();
 
@@ -1116,7 +1116,7 @@ namespace TinyECS.Test
             entity.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfNone<HealthComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -1155,7 +1155,7 @@ namespace TinyECS.Test
             clashEntity.CreateComponent<PositionComponent>();
             var clashCollector = _world.CreateCollector(
                 EntityMatcher.With.OfNone<HealthComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             clashCollector.Flush();
             clashCollector.Flush();
 
@@ -1228,7 +1228,7 @@ namespace TinyECS.Test
             entity.CreateComponent<PositionComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -1269,7 +1269,7 @@ namespace TinyECS.Test
             clashEntity.CreateComponent<PositionComponent>();
             var clashCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             clashCollector.Flush();
             clashCollector.Flush();
 
@@ -1341,7 +1341,7 @@ namespace TinyECS.Test
             entity.CreateComponent<VelocityComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -1507,7 +1507,7 @@ namespace TinyECS.Test
             entity.CreateComponent<VelocityComponent>();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>().OfNone<DamageComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             collector.Flush();
             collector.Flush();
             var beforeChange = new CollectorSnapshot(collector);
@@ -1580,7 +1580,7 @@ namespace TinyECS.Test
             var matchingEntity = _world.CreateEntity();
             var matchingCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.ChangedOnMatching);
+                EntityCollectorFlag.MatchAsChange);
             matchingCollector.Flush();
             matchingCollector.Flush();
             matchingEntity.CreateComponent<PositionComponent>();
@@ -1593,7 +1593,7 @@ namespace TinyECS.Test
             clashingLastAny.CreateComponent<VelocityComponent>();
             var clashingCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.ClashAsChange);
             clashingCollector.Flush();
             clashingCollector.Flush();
             clashingForbidden.CreateComponent<HealthComponent>();
@@ -1606,7 +1606,7 @@ namespace TinyECS.Test
             revisionEntity.CreateComponent<PositionComponent>();
             var revisionCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.ChangedOnRevision);
+                EntityCollectorFlag.RevisionAsChange);
             revisionCollector.Flush();
             revisionCollector.Flush();
             ref var revision = ref revisionEntity.GetComponent<PositionComponent>().RW;
@@ -1619,7 +1619,7 @@ namespace TinyECS.Test
             relatedEntity.CreateComponent<ManaComponent>();
             var relatedCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.ChangedOnRevision | EntityCollectorFlag.ChangeMustBeRelatedComponent);
+                EntityCollectorFlag.RevisionAsChange | EntityCollectorFlag.RelatedComponentOnly);
             relatedCollector.Flush();
             relatedCollector.Flush();
             ref var unrelated = ref relatedEntity.GetComponent<ManaComponent>().RW;
@@ -1647,7 +1647,7 @@ namespace TinyECS.Test
             defaultClashEntity.CreateComponent<VelocityComponent>();
             var defaultClashCollector = _world.CreateCollector(
                 EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
-                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+                EntityCollectorFlag.Default | EntityCollectorFlag.ClashAsChange);
             defaultClashCollector.Flush();
             defaultClashCollector.Flush();
             defaultClashEntity.DestroyComponent<VelocityComponent>();

--- a/Test/EntityCollectorTestUnit.cs
+++ b/Test/EntityCollectorTestUnit.cs
@@ -925,6 +925,737 @@ namespace TinyECS.Test
             AssertEmpty(collector.Changed);
         }
 
+
+        [Test]
+        public void EntityCollector_OfAny_MatchingAndClashing_PublishAfterFlush()
+        {
+            var entering = _world.CreateEntity();
+            var leaving = _world.CreateEntity();
+            leaving.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entering.CreateComponent<VelocityComponent>();
+            leaving.DestroyComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAny membership changes must wait for Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entering.EntityId);
+            AssertOnly(collector.Clashing, leaving.EntityId);
+            AssertOnly(collector.Collected, entering.EntityId);
+            AssertOnly(collector.Changed, entering.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAny_StillMatchedStructuralChanges_MarkChangedOnce()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<VelocityComponent>();
+            entity.DestroyComponent<PositionComponent>();
+            entity.CreateComponent<PositionComponent>();
+            entity.DestroyComponent<VelocityComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAny structural changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAny_RevisionChanges_DedupChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            ref var first = ref entity.GetComponent<PositionComponent>().RW;
+            first.X = 1;
+            ref var second = ref entity.GetComponent<PositionComponent>().RW;
+            second.Y = 2;
+
+            beforeChange.AssertMatches(collector, "OfAny revisions must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAny_ClashingFlagControlsChanged()
+        {
+            var defaultEntity = _world.CreateEntity();
+            defaultEntity.CreateComponent<PositionComponent>();
+            var defaultCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.Default);
+            defaultCollector.Flush();
+            defaultCollector.Flush();
+
+            defaultEntity.DestroyComponent<PositionComponent>();
+            defaultCollector.Flush();
+
+            AssertOnly(defaultCollector.Clashing, defaultEntity.EntityId);
+            AssertEmpty(defaultCollector.Changed);
+
+            var clashEntity = _world.CreateEntity();
+            clashEntity.CreateComponent<PositionComponent>();
+            var clashCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            clashCollector.Flush();
+            clashCollector.Flush();
+
+            clashEntity.DestroyComponent<PositionComponent>();
+            clashCollector.Flush();
+
+            AssertOnly(clashCollector.Clashing, clashEntity.EntityId);
+            AssertOnly(clashCollector.Changed, clashEntity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAny_NoneFlagSuppressesChanged()
+        {
+            var entity = _world.CreateEntity();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>(),
+                EntityCollectorFlag.None);
+
+            entity.CreateComponent<PositionComponent>();
+            collector.Flush();
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Changed);
+
+            collector.Flush();
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 3;
+            collector.Flush();
+            AssertEmpty(collector.Changed);
+
+            entity.DestroyComponent<PositionComponent>();
+            collector.Flush();
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_OfNone_MatchingAndClashing_PublishAfterFlush()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "OfNone clashing must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Collected);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_OfNone_RemoveForbidden_MatchesAfterFlush()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            entity.CreateComponent<HealthComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            AssertAllEmpty(collector);
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "removing OfNone blocker must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfNone_BounceForbidden_DedupsChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<HealthComponent>();
+            entity.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "OfNone bounce must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfNone_ClashingFlagControlsChanged()
+        {
+            var defaultEntity = _world.CreateEntity();
+            defaultEntity.CreateComponent<PositionComponent>();
+            var defaultCollector = _world.CreateCollector(
+                EntityMatcher.With.OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            defaultCollector.Flush();
+            defaultCollector.Flush();
+
+            defaultEntity.CreateComponent<HealthComponent>();
+            defaultCollector.Flush();
+
+            AssertOnly(defaultCollector.Clashing, defaultEntity.EntityId);
+            AssertEmpty(defaultCollector.Changed);
+
+            var clashEntity = _world.CreateEntity();
+            clashEntity.CreateComponent<PositionComponent>();
+            var clashCollector = _world.CreateCollector(
+                EntityMatcher.With.OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            clashCollector.Flush();
+            clashCollector.Flush();
+
+            clashEntity.CreateComponent<HealthComponent>();
+            clashCollector.Flush();
+
+            AssertOnly(clashCollector.Clashing, clashEntity.EntityId);
+            AssertOnly(clashCollector.Changed, clashEntity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfNone_NoneFlagSuppressesChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfNone<HealthComponent>(),
+                EntityCollectorFlag.None);
+            collector.Flush();
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Changed);
+
+            collector.Flush();
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 4;
+            collector.Flush();
+            AssertEmpty(collector.Changed);
+
+            entity.CreateComponent<HealthComponent>();
+            collector.Flush();
+            AssertOnly(collector.Clashing, entity.EntityId);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_OfAllAndOfNone_ForbiddenAndRequiredChanges_PublishExpectedBuffers()
+        {
+            var forbiddenExit = _world.CreateEntity();
+            var requiredExit = _world.CreateEntity();
+            var entering = _world.CreateEntity();
+            forbiddenExit.CreateComponent<PositionComponent>();
+            requiredExit.CreateComponent<PositionComponent>();
+            entering.CreateComponent<PositionComponent>();
+            entering.CreateComponent<HealthComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            forbiddenExit.CreateComponent<HealthComponent>();
+            requiredExit.DestroyComponent<PositionComponent>();
+            entering.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAll/OfNone changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entering.EntityId);
+            AssertOnly(collector.Clashing, forbiddenExit.EntityId, requiredExit.EntityId);
+            AssertOnly(collector.Collected, entering.EntityId);
+            AssertOnly(collector.Changed, entering.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAllAndOfNone_StillMatchedChanges_MarkChangedOnce()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<HealthComponent>();
+            entity.DestroyComponent<HealthComponent>();
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 9;
+            entity.CreateComponent<ManaComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAll/OfNone still-matched changes must wait for Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAllAndOfNone_ClashingFlagControlsForbiddenAndRequiredExit()
+        {
+            var defaultEntity = _world.CreateEntity();
+            defaultEntity.CreateComponent<PositionComponent>();
+            var defaultCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            defaultCollector.Flush();
+            defaultCollector.Flush();
+
+            defaultEntity.CreateComponent<HealthComponent>();
+            defaultCollector.Flush();
+            AssertOnly(defaultCollector.Clashing, defaultEntity.EntityId);
+            AssertEmpty(defaultCollector.Changed);
+
+            var clashEntity = _world.CreateEntity();
+            clashEntity.CreateComponent<PositionComponent>();
+            var clashCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            clashCollector.Flush();
+            clashCollector.Flush();
+
+            clashEntity.DestroyComponent<PositionComponent>();
+            clashCollector.Flush();
+            AssertOnly(clashCollector.Clashing, clashEntity.EntityId);
+            AssertOnly(clashCollector.Changed, clashEntity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAllAndOfAny_MissingAllOrAny_MatchesAfterCompletion()
+        {
+            var missingAny = _world.CreateEntity();
+            var missingAll = _world.CreateEntity();
+            missingAny.CreateComponent<PositionComponent>();
+            missingAll.CreateComponent<VelocityComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            AssertAllEmpty(collector);
+            var beforeChange = new CollectorSnapshot(collector);
+
+            missingAny.CreateComponent<VelocityComponent>();
+            missingAll.CreateComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAll/OfAny completion must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, missingAny.EntityId, missingAll.EntityId);
+            AssertOnly(collector.Collected, missingAny.EntityId, missingAll.EntityId);
+            AssertOnly(collector.Changed, missingAny.EntityId, missingAll.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAllAndOfAny_AllOrLastAnyRemoval_ClashesAfterFlush()
+        {
+            var missingAll = _world.CreateEntity();
+            var missingAny = _world.CreateEntity();
+            missingAll.CreateComponent<PositionComponent>();
+            missingAll.CreateComponent<VelocityComponent>();
+            missingAny.CreateComponent<PositionComponent>();
+            missingAny.CreateComponent<HealthComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            missingAll.DestroyComponent<PositionComponent>();
+            missingAny.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAll/OfAny removals must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Clashing, missingAll.EntityId, missingAny.EntityId);
+            AssertEmpty(collector.Collected);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_OfAllAndOfAny_StillMatchedAnyChanges_DedupChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            entity.CreateComponent<VelocityComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<HealthComponent>();
+            entity.DestroyComponent<VelocityComponent>();
+            entity.CreateComponent<VelocityComponent>();
+            entity.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAll/OfAny still-matched changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertEmpty(collector.Matching);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAnyAndOfNone_MatchingAndClashing_PublishExpectedBuffers()
+        {
+            var entering = _world.CreateEntity();
+            var forbiddenExit = _world.CreateEntity();
+            var lastAnyExit = _world.CreateEntity();
+            forbiddenExit.CreateComponent<PositionComponent>();
+            lastAnyExit.CreateComponent<VelocityComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entering.CreateComponent<PositionComponent>();
+            forbiddenExit.CreateComponent<HealthComponent>();
+            lastAnyExit.DestroyComponent<VelocityComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAny/OfNone changes must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entering.EntityId);
+            AssertOnly(collector.Clashing, forbiddenExit.EntityId, lastAnyExit.EntityId);
+            AssertOnly(collector.Collected, entering.EntityId);
+            AssertOnly(collector.Changed, entering.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAnyAndOfNone_RemoveForbidden_MatchesAfterFlush()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            entity.CreateComponent<HealthComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            AssertAllEmpty(collector);
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAny/OfNone unblock must remain pending before Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_OfAnyAndOfNone_StillMatchedAnyChanges_DedupChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.CreateComponent<VelocityComponent>();
+            entity.CreateComponent<ManaComponent>();
+            entity.DestroyComponent<PositionComponent>();
+
+            beforeChange.AssertMatches(collector, "OfAny/OfNone still-matched changes must wait for Flush");
+
+            collector.Flush();
+
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_CombinedMatcher_MatchesWhenAllAnyAndNoneSatisfied()
+        {
+            var alreadyMatched = _world.CreateEntity();
+            var missingAll = _world.CreateEntity();
+            var missingAny = _world.CreateEntity();
+            alreadyMatched.CreateComponent<PositionComponent>();
+            alreadyMatched.CreateComponent<VelocityComponent>();
+            missingAll.CreateComponent<VelocityComponent>();
+            missingAny.CreateComponent<PositionComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>().OfNone<DamageComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            AssertOnly(collector.Matching, alreadyMatched.EntityId);
+            AssertOnly(collector.Collected, alreadyMatched.EntityId);
+            AssertOnly(collector.Changed, alreadyMatched.EntityId);
+
+            collector.Flush();
+            missingAll.CreateComponent<PositionComponent>();
+            missingAny.CreateComponent<HealthComponent>();
+            collector.Flush();
+
+            AssertOnly(collector.Matching, missingAll.EntityId, missingAny.EntityId);
+            AssertOnly(collector.Collected, alreadyMatched.EntityId, missingAll.EntityId, missingAny.EntityId);
+            AssertOnly(collector.Changed, missingAll.EntityId, missingAny.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_CombinedMatcher_ClashesWhenAnyRequirementBreaks()
+        {
+            var forbiddenExit = _world.CreateEntity();
+            var missingAll = _world.CreateEntity();
+            var missingAny = _world.CreateEntity();
+            forbiddenExit.CreateComponent<PositionComponent>();
+            forbiddenExit.CreateComponent<VelocityComponent>();
+            missingAll.CreateComponent<PositionComponent>();
+            missingAll.CreateComponent<VelocityComponent>();
+            missingAny.CreateComponent<PositionComponent>();
+            missingAny.CreateComponent<HealthComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>().OfNone<DamageComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            forbiddenExit.CreateComponent<DamageComponent>();
+            missingAll.DestroyComponent<PositionComponent>();
+            missingAny.DestroyComponent<HealthComponent>();
+
+            beforeChange.AssertMatches(collector, "combined matcher clashing changes must wait for Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Clashing, forbiddenExit.EntityId, missingAll.EntityId, missingAny.EntityId);
+            AssertEmpty(collector.Collected);
+            AssertEmpty(collector.Changed);
+        }
+
+        [Test]
+        public void EntityCollector_CombinedMatcher_StillMatchedMixedChanges_DedupChanged()
+        {
+            var entity = _world.CreateEntity();
+            entity.CreateComponent<PositionComponent>();
+            entity.CreateComponent<VelocityComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>().OfNone<DamageComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entity.DestroyComponent<VelocityComponent>();
+            entity.CreateComponent<HealthComponent>();
+            ref var writable = ref entity.GetComponent<PositionComponent>().RW;
+            writable.X = 6;
+            entity.CreateComponent<ManaComponent>();
+
+            beforeChange.AssertMatches(collector, "combined still-matched changes must wait for Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entity.EntityId);
+            AssertEmpty(collector.Clashing);
+            AssertOnly(collector.Collected, entity.EntityId);
+            AssertOnly(collector.Changed, entity.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_CombinedMatcher_MixedEntities_DoNotPolluteBuffers()
+        {
+            var entering = _world.CreateEntity();
+            var forbiddenExit = _world.CreateEntity();
+            var lastAnyExit = _world.CreateEntity();
+            var updating = _world.CreateEntity();
+            entering.CreateComponent<PositionComponent>();
+            forbiddenExit.CreateComponent<PositionComponent>();
+            forbiddenExit.CreateComponent<VelocityComponent>();
+            lastAnyExit.CreateComponent<PositionComponent>();
+            lastAnyExit.CreateComponent<HealthComponent>();
+            updating.CreateComponent<PositionComponent>();
+            updating.CreateComponent<VelocityComponent>();
+            var collector = _world.CreateCollector(
+                EntityMatcher.With.OfAll<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>().OfNone<DamageComponent>(),
+                EntityCollectorFlag.Default);
+            collector.Flush();
+            collector.Flush();
+            var beforeChange = new CollectorSnapshot(collector);
+
+            entering.CreateComponent<VelocityComponent>();
+            forbiddenExit.CreateComponent<DamageComponent>();
+            lastAnyExit.DestroyComponent<HealthComponent>();
+            ref var writable = ref updating.GetComponent<PositionComponent>().RW;
+            writable.X = 8;
+
+            beforeChange.AssertMatches(collector, "combined mixed changes must wait for Flush");
+
+            collector.Flush();
+
+            AssertOnly(collector.Matching, entering.EntityId);
+            AssertOnly(collector.Clashing, forbiddenExit.EntityId, lastAnyExit.EntityId);
+            AssertOnly(collector.Collected, updating.EntityId, entering.EntityId);
+            AssertOnly(collector.Changed, entering.EntityId, updating.EntityId);
+        }
+
+        [Test]
+        public void EntityCollector_MatcherCombinations_FlagMatrix_ControlsChanged()
+        {
+            var noneEntity = _world.CreateEntity();
+            var noneCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.None);
+            noneEntity.CreateComponent<PositionComponent>();
+            noneCollector.Flush();
+            AssertOnly(noneCollector.Matching, noneEntity.EntityId);
+            AssertEmpty(noneCollector.Changed);
+
+            var matchingEntity = _world.CreateEntity();
+            var matchingCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.ChangedOnMatching);
+            matchingCollector.Flush();
+            matchingCollector.Flush();
+            matchingEntity.CreateComponent<PositionComponent>();
+            matchingCollector.Flush();
+            AssertOnly(matchingCollector.Changed, matchingEntity.EntityId);
+
+            var clashingForbidden = _world.CreateEntity();
+            var clashingLastAny = _world.CreateEntity();
+            clashingForbidden.CreateComponent<PositionComponent>();
+            clashingLastAny.CreateComponent<VelocityComponent>();
+            var clashingCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.ChangedOnClashing);
+            clashingCollector.Flush();
+            clashingCollector.Flush();
+            clashingForbidden.CreateComponent<HealthComponent>();
+            clashingLastAny.DestroyComponent<VelocityComponent>();
+            clashingCollector.Flush();
+            AssertOnly(clashingCollector.Clashing, clashingForbidden.EntityId, clashingLastAny.EntityId);
+            AssertOnly(clashingCollector.Changed, clashingForbidden.EntityId, clashingLastAny.EntityId);
+
+            var revisionEntity = _world.CreateEntity();
+            revisionEntity.CreateComponent<PositionComponent>();
+            var revisionCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.ChangedOnRevision);
+            revisionCollector.Flush();
+            revisionCollector.Flush();
+            ref var revision = ref revisionEntity.GetComponent<PositionComponent>().RW;
+            revision.X = 1;
+            revisionCollector.Flush();
+            AssertOnly(revisionCollector.Changed, revisionEntity.EntityId);
+
+            var relatedEntity = _world.CreateEntity();
+            relatedEntity.CreateComponent<PositionComponent>();
+            relatedEntity.CreateComponent<ManaComponent>();
+            var relatedCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.ChangedOnRevision | EntityCollectorFlag.ChangeMustBeRelatedComponent);
+            relatedCollector.Flush();
+            relatedCollector.Flush();
+            ref var unrelated = ref relatedEntity.GetComponent<ManaComponent>().RW;
+            unrelated.Value = 1;
+            relatedCollector.Flush();
+            AssertEmpty(relatedCollector.Changed);
+            ref var related = ref relatedEntity.GetComponent<PositionComponent>().RW;
+            related.X = 2;
+            relatedCollector.Flush();
+            AssertOnly(relatedCollector.Changed, relatedEntity.EntityId);
+
+            var defaultEntity = _world.CreateEntity();
+            defaultEntity.CreateComponent<PositionComponent>();
+            var defaultCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default);
+            defaultCollector.Flush();
+            defaultCollector.Flush();
+            defaultEntity.CreateComponent<HealthComponent>();
+            defaultCollector.Flush();
+            AssertOnly(defaultCollector.Clashing, defaultEntity.EntityId);
+            AssertEmpty(defaultCollector.Changed);
+
+            var defaultClashEntity = _world.CreateEntity();
+            defaultClashEntity.CreateComponent<VelocityComponent>();
+            var defaultClashCollector = _world.CreateCollector(
+                EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfNone<HealthComponent>(),
+                EntityCollectorFlag.Default | EntityCollectorFlag.ChangedOnClashing);
+            defaultClashCollector.Flush();
+            defaultClashCollector.Flush();
+            defaultClashEntity.DestroyComponent<VelocityComponent>();
+            defaultClashCollector.Flush();
+            AssertOnly(defaultClashCollector.Clashing, defaultClashEntity.EntityId);
+            AssertOnly(defaultClashCollector.Changed, defaultClashEntity.EntityId);
+        }
+
         private static void AssertAllEmpty(IEntityCollector collector)
         {
             AssertEmpty(collector.Matching);
@@ -992,6 +1723,21 @@ namespace TinyECS.Test
         {
             public float X;
             public float Y;
+        }
+
+        private struct HealthComponent : IComponent<HealthComponent>
+        {
+            public float Value;
+        }
+
+        private struct DamageComponent : IComponent<DamageComponent>
+        {
+            public float Value;
+        }
+
+        private struct ManaComponent : IComponent<ManaComponent>
+        {
+            public float Value;
         }
     }
 }

--- a/Test/EntityMatcherTestUnit.cs
+++ b/Test/EntityMatcherTestUnit.cs
@@ -424,7 +424,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.LazyAdd | EntityCollectorFlag.ChangedOnRevision | EntityCollectorFlag.LazyChange);
+                EntityCollectorFlag.ChangedOnRevision);
             
             collector.Flush();
             
@@ -440,31 +440,6 @@ namespace TinyECS.Test
             collector.Flush();
             
             Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
-        }
-
-        [Test]
-        public void EntityMatcher_Change_Existing_Component_NonLazyChange_Immediate()
-        {
-            var entity = _world.CreateEntity();
-            var collector = _world.CreateCollector(
-                EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.LazyAdd | EntityCollectorFlag.ChangedOnRevision);
-
-            collector.Flush();
-
-            Assert.IsFalse(collector.Collected.Contains(entity.EntityId));
-
-            entity.CreateComponent<PositionComponent>();
-            collector.Flush();
-
-            Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
-
-            _ = entity.GetComponent<PositionComponent>().RW;
-            Assert.IsTrue(collector.Changed.Contains(entity.EntityId));
-            collector.Flush();
-
-            Assert.IsFalse(collector.Changed.Contains(entity.EntityId));
             Assert.IsTrue(collector.Collected.Contains(entity.EntityId));
         }
 

--- a/Test/EntityMatcherTestUnit.cs
+++ b/Test/EntityMatcherTestUnit.cs
@@ -424,7 +424,7 @@ namespace TinyECS.Test
             var entity = _world.CreateEntity();
             var collector = _world.CreateCollector(
                 EntityMatcher.With.OfAll<PositionComponent>(),
-                EntityCollectorFlag.ChangedOnRevision);
+                EntityCollectorFlag.RevisionAsChange);
             
             collector.Flush();
             

--- a/Test/StressTestUnit.cs
+++ b/Test/StressTestUnit.cs
@@ -619,7 +619,7 @@ namespace TinyECS.Test
         public void StressTest_RWPerformanceBaseline_WithRevisionTrackingCollector()
         {
             const int iterations = 100000;
-            const EntityCollectorFlag collectorFlag = EntityCollectorFlag.ChangedOnRevision;
+            const EntityCollectorFlag collectorFlag = EntityCollectorFlag.RevisionAsChange;
 
             var repeatedGetter = MeasureBestRwScenario(
                 "RW baseline with revision collector (repeated getter)",

--- a/Test/StressTestUnit.cs
+++ b/Test/StressTestUnit.cs
@@ -619,8 +619,7 @@ namespace TinyECS.Test
         public void StressTest_RWPerformanceBaseline_WithRevisionTrackingCollector()
         {
             const int iterations = 100000;
-            const EntityCollectorFlag collectorFlag =
-                EntityCollectorFlag.None | EntityCollectorFlag.ChangedOnRevision | EntityCollectorFlag.LazyChange;
+            const EntityCollectorFlag collectorFlag = EntityCollectorFlag.ChangedOnRevision;
 
             var repeatedGetter = MeasureBestRwScenario(
                 "RW baseline with revision collector (repeated getter)",
@@ -676,8 +675,6 @@ namespace TinyECS.Test
             var entity = world.CreateEntity();
             var position = entity.CreateComponent<PositionComponent>();
 
-            if (collectorFlag.HasValue && (collectorFlag.Value & EntityCollectorFlag.LazyChange) != 0)
-                collector?.Flush();
             collector?.Flush();
 
             var initialRevision = position.Revision;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Rebased the branch onto latest `master`.
- Renamed branch commits to match the requested commit scopes:
  - `fix(core): make EntityCollector flush updates deferred`
  - `refactor(test): update EntityCollector flush semantics coverage`
  - `fix(test): align EntityCollector edge case expectations`
  - `feat(test): cover EntityCollector matcher combinations`
- Removed obsolete NonLazy/Lazy collector test semantics and all old Lazy flag references from the test suite.
- Reworked EntityCollector coverage around `Flush()` as the visibility boundary for `Matching`, `Clashing`, `Collected`, and `Changed`.
- Added matcher-combination coverage for `OfAny`, `OfNone`, `OfAll + OfAny`, `OfAll + OfNone`, `OfAny + OfNone`, combined `OfAll + OfAny + OfNone`, and representative flag behavior.

### Testing
- `dotnet test --verbosity normal` passed: 295 tests.
- `git diff -- ECS` produced no output for the latest test-only coverage addition.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b709892-0136-420c-9aa9-d42143dbcc41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b709892-0136-420c-9aa9-d42143dbcc41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

