### PR TITLE
fix(core): release components when destroying entities

### DIFF
--- a/ECS/Managers/EntityManager.cs
+++ b/ECS/Managers/EntityManager.cs
@@ -131,15 +131,17 @@ namespace CoreECS.Managers
             Assertion.IsTrue(m_init);
             Assertion.IsFalse(m_shutdown);
             
-            if (m_entityCaches.TryGetValue(entityId, out var graph))
+            if (m_entityCaches.Remove(entityId, out var graph))
             {
                 graph.WishDestroy = true;
                 while (graph.RwComponents.Count > 0)
                 {
-                    m_compManager.DestroyComponent(graph.RwComponents[^1]);
+                    var last = graph.RwComponents.Count - 1;
+                    var component = graph.RwComponents[last];
+                    graph.RwComponents.RemoveAt(last);
+                    m_compManager.DestroyComponent(component);
                 }
 
-                m_entityCaches.Remove(entityId);
                 OnEntityLoseComp.Emit(in graph, (Type)null, static (h, g, t) => h(g, t));
                 EntityGraph.Pool.Release(graph);
             }

--- a/ECS/Managers/EntityManager.cs
+++ b/ECS/Managers/EntityManager.cs
@@ -134,13 +134,11 @@ namespace CoreECS.Managers
             if (m_entityCaches.Remove(entityId, out var graph))
             {
                 graph.WishDestroy = true;
-                while (graph.RwComponents.Count > 0)
+                for (var i = 0; i < graph.RwComponents.Count; i++)
                 {
-                    var last = graph.RwComponents.Count - 1;
-                    var component = graph.RwComponents[last];
-                    graph.RwComponents.RemoveAt(last);
-                    m_compManager.DestroyComponent(component);
+                    m_compManager.DestroyComponent(graph.RwComponents[i]);
                 }
+                graph.RwComponents.Clear();
 
                 OnEntityLoseComp.Emit(in graph, (Type)null, static (h, g, t) => h(g, t));
                 EntityGraph.Pool.Release(graph);

--- a/ECS/Managers/EntityManager.cs
+++ b/ECS/Managers/EntityManager.cs
@@ -131,10 +131,15 @@ namespace CoreECS.Managers
             Assertion.IsTrue(m_init);
             Assertion.IsFalse(m_shutdown);
             
-            if (m_entityCaches.Remove(entityId, out var graph))
+            if (m_entityCaches.TryGetValue(entityId, out var graph))
             {
-                graph.RwComponents.Clear();
                 graph.WishDestroy = true;
+                while (graph.RwComponents.Count > 0)
+                {
+                    m_compManager.DestroyComponent(graph.RwComponents[^1]);
+                }
+
+                m_entityCaches.Remove(entityId);
                 OnEntityLoseComp.Emit(in graph, (Type)null, static (h, g, t) => h(g, t));
                 EntityGraph.Pool.Release(graph);
             }

--- a/Test/EntityManagerTestUnit.cs
+++ b/Test/EntityManagerTestUnit.cs
@@ -83,25 +83,34 @@ namespace CoreECS.Test
         }
         
         [Test]
-        public void EntityManager_DestroyEntity_ClearsComponentsAndSetsWishDestroy()
+        public void EntityManager_DestroyEntity_ReleasesComponentsAndMarksWishDestroyDuringNotification()
         {
             // Arrange
-            var entityGraph = _entityManager.CreateEntity(0);
-            var entityId = entityGraph.EntityId;
-            
-            // Add some mock components to the entity graph
-            var mockComponent = new ComponentRefCore(new MockComponentRefLocator(), 0, 1);
-            entityGraph.RwComponents.Add(mockComponent);
-            
-            // Verify components were added
+            var entity = _world.CreateEntity();
+            var entityGraph = _entityManager.GetEntity(entity.EntityId);
+            var componentRef = entity.CreateComponent<PositionComponent>();
+            var notifiedDestroyed = false;
+            var notifiedWishDestroy = false;
+            var notifiedComponentCount = -1;
+
+            _entityManager.OnEntityLoseComp.Add((graph, type) => {
+                if (type != null) return;
+                notifiedDestroyed = true;
+                notifiedWishDestroy = graph.WishDestroy;
+                notifiedComponentCount = graph.RwComponents.Count;
+            });
+
             Assert.AreEqual(1, entityGraph.RwComponents.Count);
             
             // Act
-            _entityManager.DestroyEntity(entityId);
+            _entityManager.DestroyEntity(entity.EntityId);
             
             // Assert
             Assert.AreEqual(0, entityGraph.RwComponents.Count);
-            Assert.IsFalse(entityGraph.WishDestroy);
+            Assert.IsFalse(componentRef.NotNull);
+            Assert.IsTrue(notifiedDestroyed);
+            Assert.IsTrue(notifiedWishDestroy);
+            Assert.AreEqual(0, notifiedComponentCount);
         }
         
         [Test]

--- a/Test/IntegrationTestUnit.cs
+++ b/Test/IntegrationTestUnit.cs
@@ -191,22 +191,32 @@ namespace CoreECS.Test
             // Arrange
             var world = new World();
             world.Startup();
+            LifecycleComponent.ResetTracking();
             
             var entity = world.CreateEntity();
+            var entityId = entity.EntityId;
+            var componentManager = world.GetManager<ComponentManager>();
             
             // Act
             var componentRef = entity.CreateComponent<LifecycleComponent>();
+            var store = componentManager.GetComponentStore<LifecycleComponent>(false);
             
             // Assert
             Assert.IsTrue(componentRef.RW.OnCreateCalled);
             Assert.IsFalse(componentRef.RW.OnDestroyCalled);
+            Assert.AreEqual(1, LifecycleComponent.OnCreateCount);
+            Assert.AreEqual(entityId, LifecycleComponent.LastCreatedEntityId);
+            Assert.AreEqual(1, store.Allocated);
             
             // Act
             world.DestroyEntity(entity);
+            componentManager.CleanupComponents();
             
             // Assert
-            // Note: In a real implementation, we would need to verify that OnDestroy was called
-            // This might require a more complex setup with event tracking
+            Assert.IsFalse(componentRef.NotNull);
+            Assert.AreEqual(1, LifecycleComponent.OnDestroyCount);
+            Assert.AreEqual(entityId, LifecycleComponent.LastDestroyedEntityId);
+            Assert.AreEqual(0, store.Allocated);
             
             // Cleanup
             world.Shutdown();
@@ -242,16 +252,33 @@ namespace CoreECS.Test
         
         private struct LifecycleComponent : IComponent<LifecycleComponent>
         {
+            public static int OnCreateCount;
+            public static int OnDestroyCount;
+            public static ulong LastCreatedEntityId;
+            public static ulong LastDestroyedEntityId;
+            
             public bool OnCreateCalled;
             public bool OnDestroyCalled;
             
+            public static void ResetTracking()
+            {
+                OnCreateCount = 0;
+                OnDestroyCount = 0;
+                LastCreatedEntityId = 0;
+                LastDestroyedEntityId = 0;
+            }
+            
             public void OnCreate(ulong entityId)
             {
+                OnCreateCount += 1;
+                LastCreatedEntityId = entityId;
                 OnCreateCalled = true;
             }
             
             public void OnDestroy(ulong entityId)
             {
+                OnDestroyCount += 1;
+                LastDestroyedEntityId = entityId;
                 OnDestroyCalled = true;
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Release all attached components through `ComponentManager.DestroyComponent` before recycling an entity graph.
- Combine entity lookup/removal with `Remove(entityId, out graph)`, iterate existing `RwComponents`, then clear the list after all component releases finish.
- Add regression coverage for component reference invalidation, `OnDestroy`, and component store cleanup after entity destruction.

### Testing
- `dotnet test --filter "ComponentLifecycle_OnCreateAndOnDestroyEvents|EntityManager_DestroyEntity_ReleasesComponentsAndMarksWishDestroyDuringNotification" --verbosity normal`
- `dotnet test --verbosity normal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e8489ac-007c-4b1a-8bae-c904fc354f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e8489ac-007c-4b1a-8bae-c904fc354f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

