### PR TITLE
fix(core): include world in entity equality

### DIFF
--- a/ECS/Entity.cs
+++ b/ECS/Entity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using CoreECS.Defines;
 using CoreECS.Managers;
 using CoreECS.Utils;
@@ -256,26 +257,55 @@ namespace CoreECS
 
         #region Equality
 
+        /// <summary>
+        /// Determines whether this entity represents the same entity identity as another entity.
+        /// </summary>
+        /// <param name="other">The entity to compare with this entity</param>
+        /// <returns>True when both entities belong to the same world and have the same ID and generation</returns>
         public bool Equals(Entity other)
         {
-            return m_entityId == other.m_entityId && m_generation == other.m_generation;
+            return ReferenceEquals(m_world, other.m_world) &&
+                   m_entityId == other.m_entityId &&
+                   m_generation == other.m_generation;
         }
 
+        /// <summary>
+        /// Determines whether this entity represents the same entity identity as another object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this entity</param>
+        /// <returns>True when the object is an entity with the same world, ID, and generation</returns>
         public override bool Equals(object obj)
         {
             return obj is Entity other && Equals(other);
         }
 
+        /// <summary>
+        /// Gets a hash code for this entity identity.
+        /// </summary>
+        /// <returns>A hash code based on world identity, entity ID, and generation</returns>
         public override int GetHashCode()
         {
-            return HashCode.Combine(m_entityId, m_generation);
+            var worldHash = m_world == null ? 0 : RuntimeHelpers.GetHashCode(m_world);
+            return HashCode.Combine(worldHash, m_entityId, m_generation);
         }
 
+        /// <summary>
+        /// Determines whether two entities represent the same entity identity.
+        /// </summary>
+        /// <param name="left">The first entity to compare</param>
+        /// <param name="right">The second entity to compare</param>
+        /// <returns>True when both entities belong to the same world and have the same ID and generation</returns>
         public static bool operator ==(Entity left, Entity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Determines whether two entities represent different entity identities.
+        /// </summary>
+        /// <param name="left">The first entity to compare</param>
+        /// <param name="right">The second entity to compare</param>
+        /// <returns>True when the entities differ by world, ID, or generation</returns>
         public static bool operator !=(Entity left, Entity right)
         {
             return !left.Equals(right);

--- a/Test/EntityTestUnit.cs
+++ b/Test/EntityTestUnit.cs
@@ -1,4 +1,5 @@
 using CoreECS.Defines;
+using CoreECS.Managers;
 
 namespace CoreECS.Test
 {
@@ -30,6 +31,40 @@ namespace CoreECS.Test
             Assert.IsTrue(entity.IsValid);
             Assert.AreEqual(_world, entity.World);
             Assert.IsTrue(entity.EntityId > 0);
+        }
+
+        [Test]
+        public void Entity_Equals_DifferentWorldWithSameIdAndGeneration_ReturnsFalse()
+        {
+            // Arrange
+            var otherWorld = new World();
+            otherWorld.Startup();
+
+            try
+            {
+                var entity = _world.CreateEntity();
+                var graph = _world.GetManager<EntityManager>().GetEntity(entity.EntityId);
+                var sameIdAndGenerationInOtherWorld = new Entity(otherWorld, entity.EntityId, graph.Generation);
+
+                // Act
+                var equalsResult = entity.Equals(sameIdAndGenerationInOtherWorld);
+                var reverseEqualsResult = sameIdAndGenerationInOtherWorld.Equals(entity);
+                var equalityOperatorResult = entity == sameIdAndGenerationInOtherWorld;
+                var inequalityOperatorResult = entity != sameIdAndGenerationInOtherWorld;
+
+                // Assert
+                Assert.AreEqual(entity.EntityId, sameIdAndGenerationInOtherWorld.EntityId);
+                Assert.AreNotSame(entity.World, sameIdAndGenerationInOtherWorld.World);
+                Assert.IsFalse(equalsResult);
+                Assert.IsFalse(reverseEqualsResult);
+                Assert.IsFalse(equalityOperatorResult);
+                Assert.IsTrue(inequalityOperatorResult);
+                Assert.AreNotEqual(entity.GetHashCode(), sameIdAndGenerationInOtherWorld.GetHashCode());
+            }
+            finally
+            {
+                otherWorld.Shutdown();
+            }
         }
         
         [Test]

--- a/Test/EntityTestUnit.cs
+++ b/Test/EntityTestUnit.cs
@@ -53,13 +53,13 @@ namespace CoreECS.Test
                 var inequalityOperatorResult = entity != sameIdAndGenerationInOtherWorld;
 
                 // Assert
-                Assert.AreEqual(entity.EntityId, sameIdAndGenerationInOtherWorld.EntityId);
-                Assert.AreNotSame(entity.World, sameIdAndGenerationInOtherWorld.World);
-                Assert.IsFalse(equalsResult);
-                Assert.IsFalse(reverseEqualsResult);
-                Assert.IsFalse(equalityOperatorResult);
-                Assert.IsTrue(inequalityOperatorResult);
-                Assert.AreNotEqual(entity.GetHashCode(), sameIdAndGenerationInOtherWorld.GetHashCode());
+                Assert.That(sameIdAndGenerationInOtherWorld.EntityId, Is.EqualTo(entity.EntityId));
+                Assert.That(sameIdAndGenerationInOtherWorld.World, Is.Not.SameAs(entity.World));
+                Assert.That(equalsResult, Is.False);
+                Assert.That(reverseEqualsResult, Is.False);
+                Assert.That(equalityOperatorResult, Is.False);
+                Assert.That(inequalityOperatorResult, Is.True);
+                Assert.That(sameIdAndGenerationInOtherWorld.GetHashCode(), Is.Not.EqualTo(entity.GetHashCode()));
             }
             finally
             {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Include the owning world instance in `Entity` equality and hash code identity.
- Add a regression test for entities with the same ID and generation from different worlds.

## Testing
- `dotnet test --verbosity normal` (302 passed; existing analyzer warnings remain, 0 errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc850259-3002-4158-9f1e-15760d067925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc850259-3002-4158-9f1e-15760d067925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

