### PR TITLE
fix(core): validate system registration before unregister

### DIFF
--- a/ECS/Managers/SystemManager.cs
+++ b/ECS/Managers/SystemManager.cs
@@ -269,13 +269,15 @@ namespace CoreECS.Managers
         /// Unregisters a system type from the manager.
         /// </summary>
         /// <param name="systemType">The type of system to unregister</param>
+        /// <exception cref="InvalidOperationException">Thrown when the system is not registered</exception>
         public void UnregisterSystem(Type systemType)
         {
             Assertion.IsFalse(m_shutdown, "SystemManager has already shutdown.");
             Assertion.IsNotNull(systemType);
             Assertion.IsParentTypeTo<ISystem>(systemType);
             
-            var sys = m_systemTransformer[systemType];
+            if (!m_systemTransformer.TryGetValue(systemType, out var sys))
+                throw new InvalidOperationException($"System {systemType.FullName} is not registered.");
 
             if (m_changable)
             {
@@ -285,7 +287,7 @@ namespace CoreECS.Managers
             }
             else
             {
-                if (m_systemTransformer.ContainsKey(systemType) && !m_delSystems.Contains(systemType))
+                if (!m_delSystems.Contains(systemType))
                     m_delSystems.Enqueue(systemType);
             }
         }

--- a/ECS/World.cs
+++ b/ECS/World.cs
@@ -300,7 +300,7 @@ namespace CoreECS
         /// Unregisters a system from the world.
         /// </summary>
         /// <param name="systemType">The type of system to unregister</param>
-        /// <exception cref="InvalidOperationException">Thrown when system manager is not available</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the world is not ready, system manager is not available, or the system is not registered</exception>
         public void UnregisterSystem(Type systemType)
         {
             Assertion.IsTrue(Ready, "World is not ready");
@@ -315,7 +315,7 @@ namespace CoreECS
         /// Unregisters a system from the world.
         /// </summary>
         /// <typeparam name="T">The type of system to unregister, must implement ISystem</typeparam>
-        /// <exception cref="InvalidOperationException">Thrown when system manager is not available</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the world is not ready, system manager is not available, or the system is not registered</exception>
         public void UnregisterSystem<T>() where T : class, ISystem
         {
             Assertion.IsTrue(Ready, "World is not ready");

--- a/Test/SystemTestUnit.cs
+++ b/Test/SystemTestUnit.cs
@@ -59,6 +59,19 @@ namespace CoreECS.Test
             // Assert
             Assert.IsFalse(systemManager.SystemTransformer.ContainsKey(typeof(TestSystem)));
         }
+
+        [Test]
+        public void SystemManager_UnregisterSystem_ThrowsWhenSystemIsNotRegistered()
+        {
+            // Arrange
+            var systemManager = _world.GetManager<SystemManager>();
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                systemManager.UnregisterSystem(typeof(TestSystem)));
+
+            Assert.AreEqual("System CoreECS.Test.SystemTestUnit+TestSystem is not registered.", ex!.Message);
+        }
         
         [Test]
         public void SystemManager_CanExecuteSystems()

--- a/Test/WorldTestUnit.cs
+++ b/Test/WorldTestUnit.cs
@@ -258,6 +258,23 @@ namespace CoreECS.Test
         }
 
         [Test]
+        public void World_UnregisterSystem_ThrowsWhenSystemIsNotRegistered()
+        {
+            // Arrange
+            var world = new World();
+            world.Startup();
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                world.UnregisterSystem<TestSystem>());
+
+            Assert.AreEqual("System CoreECS.Test.WorldTestUnit+TestSystem is not registered.", ex!.Message);
+
+            // Cleanup
+            world.Shutdown();
+        }
+
+        [Test]
         public void World_GetEntitiesWithComponent_Ulong_ReturnsIdsForEntitiesWithComponent()
         {
             var world = new World();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Validate that a system type is registered before `SystemManager.UnregisterSystem` reads the system dictionary.
- Document the propagated `InvalidOperationException` on `World.UnregisterSystem` overloads.
- Add regression coverage for direct manager and world unregister calls on missing systems.

### Testing
- `dotnet test --verbosity normal` — passed, 303 tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-682065a3-c0fe-45ab-b026-a5b9733b8ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-682065a3-c0fe-45ab-b026-a5b9733b8ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

