### PR TITLE
doc(core): add matcher extension XML docs

### DIFF
--- a/ECS/EntityMatcherExtension.cs
+++ b/ECS/EntityMatcherExtension.cs
@@ -2,10 +2,20 @@ using CoreECS.Defines;
 
 namespace CoreECS
 {
+    /// <summary>
+    /// Provides extension methods for composing entity matchers with multiple component types and creating collectors.
+    /// </summary>
     public static class EntityMatcherExtension
     {
         #region OfAll
 
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -13,6 +23,14 @@ namespace CoreECS
             return matcher.OfAll<T1>().OfAll<T2>();
         }
         
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <typeparam name="T3">Third required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2, T3>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -21,6 +39,15 @@ namespace CoreECS
             return matcher.OfAll<T1>().OfAll<T2>().OfAll<T3>();
         }
         
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <typeparam name="T3">Third required component type.</typeparam>
+        /// <typeparam name="T4">Fourth required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2, T3, T4>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -30,6 +57,16 @@ namespace CoreECS
             return matcher.OfAll<T1>().OfAll<T2>().OfAll<T3>().OfAll<T4>();
         }
         
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <typeparam name="T3">Third required component type.</typeparam>
+        /// <typeparam name="T4">Fourth required component type.</typeparam>
+        /// <typeparam name="T5">Fifth required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2, T3, T4, T5>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -40,6 +77,17 @@ namespace CoreECS
             return matcher.OfAll<T1>().OfAll<T2>().OfAll<T3>().OfAll<T4>().OfAll<T5>();
         }
         
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <typeparam name="T3">Third required component type.</typeparam>
+        /// <typeparam name="T4">Fourth required component type.</typeparam>
+        /// <typeparam name="T5">Fifth required component type.</typeparam>
+        /// <typeparam name="T6">Sixth required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2, T3, T4, T5, T6>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -51,6 +99,18 @@ namespace CoreECS
             return matcher.OfAll<T1>().OfAll<T2>().OfAll<T3>().OfAll<T4>().OfAll<T5>().OfAll<T6>();
         }
         
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <typeparam name="T3">Third required component type.</typeparam>
+        /// <typeparam name="T4">Fourth required component type.</typeparam>
+        /// <typeparam name="T5">Fifth required component type.</typeparam>
+        /// <typeparam name="T6">Sixth required component type.</typeparam>
+        /// <typeparam name="T7">Seventh required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2, T3, T4, T5, T6, T7>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -63,6 +123,19 @@ namespace CoreECS
             return matcher.OfAll<T1>().OfAll<T2>().OfAll<T3>().OfAll<T4>().OfAll<T5>().OfAll<T6>().OfAll<T7>();
         }
         
+        /// <summary>
+        /// Requires entities to have all of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First required component type.</typeparam>
+        /// <typeparam name="T2">Second required component type.</typeparam>
+        /// <typeparam name="T3">Third required component type.</typeparam>
+        /// <typeparam name="T4">Fourth required component type.</typeparam>
+        /// <typeparam name="T5">Fifth required component type.</typeparam>
+        /// <typeparam name="T6">Sixth required component type.</typeparam>
+        /// <typeparam name="T7">Seventh required component type.</typeparam>
+        /// <typeparam name="T8">Eighth required component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAllOfEntityMatcher OfAll<T1, T2, T3, T4, T5, T6, T7, T8>(this IAllOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -80,6 +153,13 @@ namespace CoreECS
 
         #region OfAny
 
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -87,6 +167,14 @@ namespace CoreECS
             return matcher.OfAny<T1>().OfAny<T2>();
         }
         
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <typeparam name="T3">Third accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2, T3>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -95,6 +183,15 @@ namespace CoreECS
             return matcher.OfAny<T1>().OfAny<T2>().OfAny<T3>();
         }
         
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <typeparam name="T3">Third accepted component type.</typeparam>
+        /// <typeparam name="T4">Fourth accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2, T3, T4>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -104,6 +201,16 @@ namespace CoreECS
             return matcher.OfAny<T1>().OfAny<T2>().OfAny<T3>().OfAny<T4>();
         }
         
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <typeparam name="T3">Third accepted component type.</typeparam>
+        /// <typeparam name="T4">Fourth accepted component type.</typeparam>
+        /// <typeparam name="T5">Fifth accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2, T3, T4, T5>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -114,6 +221,17 @@ namespace CoreECS
             return matcher.OfAny<T1>().OfAny<T2>().OfAny<T3>().OfAny<T4>().OfAny<T5>();
         }
         
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <typeparam name="T3">Third accepted component type.</typeparam>
+        /// <typeparam name="T4">Fourth accepted component type.</typeparam>
+        /// <typeparam name="T5">Fifth accepted component type.</typeparam>
+        /// <typeparam name="T6">Sixth accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2, T3, T4, T5, T6>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -125,6 +243,18 @@ namespace CoreECS
             return matcher.OfAny<T1>().OfAny<T2>().OfAny<T3>().OfAny<T4>().OfAny<T5>().OfAny<T6>();
         }
         
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <typeparam name="T3">Third accepted component type.</typeparam>
+        /// <typeparam name="T4">Fourth accepted component type.</typeparam>
+        /// <typeparam name="T5">Fifth accepted component type.</typeparam>
+        /// <typeparam name="T6">Sixth accepted component type.</typeparam>
+        /// <typeparam name="T7">Seventh accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2, T3, T4, T5, T6, T7>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -137,6 +267,19 @@ namespace CoreECS
             return matcher.OfAny<T1>().OfAny<T2>().OfAny<T3>().OfAny<T4>().OfAny<T5>().OfAny<T6>().OfAny<T7>();
         }
         
+        /// <summary>
+        /// Includes entities that have at least one of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First accepted component type.</typeparam>
+        /// <typeparam name="T2">Second accepted component type.</typeparam>
+        /// <typeparam name="T3">Third accepted component type.</typeparam>
+        /// <typeparam name="T4">Fourth accepted component type.</typeparam>
+        /// <typeparam name="T5">Fifth accepted component type.</typeparam>
+        /// <typeparam name="T6">Sixth accepted component type.</typeparam>
+        /// <typeparam name="T7">Seventh accepted component type.</typeparam>
+        /// <typeparam name="T8">Eighth accepted component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static IAnyOfEntityMatcher OfAny<T1, T2, T3, T4, T5, T6, T7, T8>(this IAnyOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -154,6 +297,13 @@ namespace CoreECS
 
         #region OfNone
 
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -161,6 +311,14 @@ namespace CoreECS
             return matcher.OfNone<T1>().OfNone<T2>();
         }
         
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <typeparam name="T3">Third excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2, T3>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -169,6 +327,15 @@ namespace CoreECS
             return matcher.OfNone<T1>().OfNone<T2>().OfNone<T3>();
         }
         
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <typeparam name="T3">Third excluded component type.</typeparam>
+        /// <typeparam name="T4">Fourth excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2, T3, T4>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -178,6 +345,16 @@ namespace CoreECS
             return matcher.OfNone<T1>().OfNone<T2>().OfNone<T3>().OfNone<T4>();
         }
         
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <typeparam name="T3">Third excluded component type.</typeparam>
+        /// <typeparam name="T4">Fourth excluded component type.</typeparam>
+        /// <typeparam name="T5">Fifth excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2, T3, T4, T5>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -188,6 +365,17 @@ namespace CoreECS
             return matcher.OfNone<T1>().OfNone<T2>().OfNone<T3>().OfNone<T4>().OfNone<T5>();
         }
         
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <typeparam name="T3">Third excluded component type.</typeparam>
+        /// <typeparam name="T4">Fourth excluded component type.</typeparam>
+        /// <typeparam name="T5">Fifth excluded component type.</typeparam>
+        /// <typeparam name="T6">Sixth excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2, T3, T4, T5, T6>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -199,6 +387,18 @@ namespace CoreECS
             return matcher.OfNone<T1>().OfNone<T2>().OfNone<T3>().OfNone<T4>().OfNone<T5>().OfNone<T6>();
         }
         
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <typeparam name="T3">Third excluded component type.</typeparam>
+        /// <typeparam name="T4">Fourth excluded component type.</typeparam>
+        /// <typeparam name="T5">Fifth excluded component type.</typeparam>
+        /// <typeparam name="T6">Sixth excluded component type.</typeparam>
+        /// <typeparam name="T7">Seventh excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2, T3, T4, T5, T6, T7>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -211,6 +411,19 @@ namespace CoreECS
             return matcher.OfNone<T1>().OfNone<T2>().OfNone<T3>().OfNone<T4>().OfNone<T5>().OfNone<T6>().OfNone<T7>();
         }
         
+        /// <summary>
+        /// Excludes entities that have any of the specified component types.
+        /// </summary>
+        /// <param name="matcher">Matcher to extend.</param>
+        /// <typeparam name="T1">First excluded component type.</typeparam>
+        /// <typeparam name="T2">Second excluded component type.</typeparam>
+        /// <typeparam name="T3">Third excluded component type.</typeparam>
+        /// <typeparam name="T4">Fourth excluded component type.</typeparam>
+        /// <typeparam name="T5">Fifth excluded component type.</typeparam>
+        /// <typeparam name="T6">Sixth excluded component type.</typeparam>
+        /// <typeparam name="T7">Seventh excluded component type.</typeparam>
+        /// <typeparam name="T8">Eighth excluded component type.</typeparam>
+        /// <returns>This matcher instance for method chaining.</returns>
         public static INoneOfEntityMatcher OfNone<T1, T2, T3, T4, T5, T6, T7, T8>(this INoneOfEntityMatcher matcher)
             where T1 : struct, IComponent<T1>
             where T2 : struct, IComponent<T2>
@@ -226,6 +439,14 @@ namespace CoreECS
 
         #endregion
         
+        /// <summary>
+        /// Creates an entity collector from the matcher in the specified world.
+        /// </summary>
+        /// <param name="matcher">Matcher used to filter collected entities.</param>
+        /// <param name="world">World that owns the collector and entity managers.</param>
+        /// <param name="flag">Flags controlling which entity changes are tracked by the collector.</param>
+        /// <returns>A collector that tracks entities matching the matcher.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the world is not ready or its entity match manager is unavailable.</exception>
         public static IEntityCollector Build(this IEntityMatcher matcher,
             World world, EntityCollectorFlag flag = EntityCollectorFlag.Default)
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Added XML documentation to `EntityMatcherExtension`, including all `OfAll`, `OfAny`, `OfNone`, and `Build` overloads.
- Documented matcher parameters, generic component type parameters, return values, and `Build` exception behavior.

### Testing
- `dotnet build`
- `dotnet test --verbosity normal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48aa384b-25ba-4dfb-a143-a3016f1c81cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48aa384b-25ba-4dfb-a143-a3016f1c81cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

