### PR TITLE
fix(core): skip stale component entity ids

### DIFF
--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -158,7 +158,8 @@ namespace CoreECS.Managers
         /// <summary>
         /// Rearranges the components in this store to optimize memory usage.
         /// </summary>
-        public abstract void Rearrange();
+        /// <returns>The number of invalid component slots removed from the allocated range.</returns>
+        public abstract int Rearrange();
 
         /// <summary>
         /// Sets the callbacks used by this store.
@@ -422,21 +423,23 @@ namespace CoreECS.Managers
         /// <returns>The position of the allocated component in the store</returns>
         public int Fix(ulong entityId, TComp initialValue)
         {
+            const int requiredSlots = 1;
             var pos = Allocated;
             var capa = m_components.Length;
             
             // Check if we need to expand the array
             if (NeedsMoreSpace(pos, capa))
             {
+                var compactedCount = 0;
                 if (m_needRearrange)
                 {
-                    Rearrange();
+                    compactedCount = Rearrange();
                     pos = Allocated;
-                    capa = m_components.Length;
                 }
 
-                if (NeedsMoreSpace(pos, capa))
+                if (compactedCount < requiredSlots)
                 {
+                    capa = m_components.Length;
                     var newSize = (int) MathF.Floor(MathF.Max(pos + 1, MathF.Round(capa * AutoIncreaseRate)));
                     Array.Resize(ref m_components, newSize);
                 }
@@ -503,10 +506,9 @@ namespace CoreECS.Managers
         /// <summary>
         /// Rearranges the components in this store to optimize memory usage.
         /// </summary>
-        public override void Rearrange()
+        /// <returns>The number of invalid component slots removed from the allocated range.</returns>
+        public override int Rearrange()
         {
-            if (!m_needRearrange) return;
-
             var oldAllocated = Allocated;
             var left = 0;
             var right = oldAllocated - 1;
@@ -530,6 +532,7 @@ namespace CoreECS.Managers
 
             Allocated = right + 1;
             m_needRearrange = false;
+            return oldAllocated - Allocated;
         }
 
         /// <summary>

--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -228,7 +228,7 @@ namespace CoreECS.Managers
                 if (offset >= m_store.Allocated) return false;
                 ref var g = ref m_store.m_components[offset];
                 
-                return g.Version == version;
+                return g.Entity != 0 && g.Version == version;
             }
 
             /// <summary>
@@ -297,6 +297,7 @@ namespace CoreECS.Managers
             {
                 if (offset >= m_store.Allocated) return null;
                 ref var gs = ref m_store.m_components[offset];
+                if (gs.Entity == 0) return null;
 
                 return gs.RefCore;
             }
@@ -311,6 +312,7 @@ namespace CoreECS.Managers
             {
                 if (offset >= m_store.Allocated) return 0;
                 ref var gs = ref m_store.m_components[offset];
+                if (gs.Entity == 0) return 0;
 
                 return gs.Revision;
             }
@@ -324,6 +326,7 @@ namespace CoreECS.Managers
             {
                 if (offset >= m_store.Allocated) return 0;
                 ref var gs = ref m_store.m_components[offset];
+                if (gs.Entity == 0) return 0;
 
                 gs.Revision = (gs.Revision % uint.MaxValue) + 1;
                 m_store.m_revisionChanged?.Invoke(gs.RefCore, gs.Entity);
@@ -355,11 +358,6 @@ namespace CoreECS.Managers
         /// </summary>
         private Group[] m_components;
         
-        /// <summary>
-        /// Released but unfreed entity ID.
-        /// </summary>
-        private List<int> m_markedCleanupPos;
-
         /// <summary>
         /// Gets the reference locator of this store.
         /// </summary>
@@ -452,7 +450,7 @@ namespace CoreECS.Managers
 
         /// <summary>
         /// Releases a component in this store at the specified position.
-        /// Uses a swap-with-last strategy to maintain a compact array.
+        /// Marks the component slot as invalid so it can be compacted on the next rearrange.
         /// </summary>
         /// <param name="pos">The position of the component to release</param>
         /// <returns>True if the component was successfully released, false otherwise</returns>
@@ -476,8 +474,6 @@ namespace CoreECS.Managers
             posGs.Entity = 0;
             ComponentRefCore.Pool.Release(posGs.RefCore);
             posGs.RefCore = null;
-            
-            m_markedCleanupPos.Add(pos);
             return true;
         }
 
@@ -486,20 +482,22 @@ namespace CoreECS.Managers
         /// </summary>
         public override void Rearrange()
         {
-            m_markedCleanupPos.Sort();
-            for (var i = 0; i < m_markedCleanupPos.Count; i++)
+            var writePos = 0;
+            for (var readPos = 0; readPos < Allocated; readPos++)
             {
-                var emptyPos = m_markedCleanupPos[^(i + 1)];
-                var lastPos = Allocated - 1 - i;
-                if (emptyPos >= lastPos) continue;
-                
-                m_components[emptyPos] = m_components[lastPos];
-                ref var gs = ref m_components[emptyPos];
-                gs.RefCore.Relocate(emptyPos);
+                if (m_components[readPos].Entity == 0) continue;
+
+                if (writePos != readPos)
+                {
+                    m_components[writePos] = m_components[readPos];
+                    ref var gs = ref m_components[writePos];
+                    gs.RefCore?.Relocate(writePos);
+                }
+
+                writePos += 1;
             }
 
-            Allocated -= m_markedCleanupPos.Count;
-            m_markedCleanupPos.Clear();
+            Allocated = writePos;
         }
 
         /// <summary>
@@ -534,7 +532,6 @@ namespace CoreECS.Managers
         public ComponentStore(int initialSize = 100, float autoIncreaseRate = 2, float autoIncreaseTriggerEdge = 1.2f)
         {
             m_components = new Group[initialSize];
-            m_markedCleanupPos = new(initialSize);
             AutoIncreaseRate = autoIncreaseRate;
             AutoIncreaseTriggerEdge = autoIncreaseTriggerEdge;
         }
@@ -545,7 +542,6 @@ namespace CoreECS.Managers
         public ComponentStore()
         {
             m_components = new Group[100];
-            m_markedCleanupPos = new(100);
             AutoIncreaseRate = 2;
             AutoIncreaseTriggerEdge = 1.2f;
         }

--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -482,22 +482,30 @@ namespace CoreECS.Managers
         /// </summary>
         public override void Rearrange()
         {
-            var writePos = 0;
-            for (var readPos = 0; readPos < Allocated; readPos++)
+            var oldAllocated = Allocated;
+            var left = 0;
+            var right = oldAllocated - 1;
+
+            while (left <= right)
             {
-                if (m_components[readPos].Entity == 0) continue;
+                while (left <= right && m_components[left].Entity != 0)
+                    left += 1;
 
-                if (writePos != readPos)
-                {
-                    m_components[writePos] = m_components[readPos];
-                    ref var gs = ref m_components[writePos];
-                    gs.RefCore?.Relocate(writePos);
-                }
+                while (left <= right && m_components[right].Entity == 0)
+                    right -= 1;
 
-                writePos += 1;
+                if (left > right) break;
+
+                m_components[left] = m_components[right];
+                ref var gs = ref m_components[left];
+                gs.RefCore?.Relocate(left);
+                left += 1;
+                right -= 1;
             }
 
-            Allocated = writePos;
+            Allocated = right + 1;
+            if (Allocated < oldAllocated)
+                Array.Clear(m_components, Allocated, oldAllocated - Allocated);
         }
 
         /// <summary>

--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -357,6 +357,11 @@ namespace CoreECS.Managers
         /// Array of component groups containing component data and metadata.
         /// </summary>
         private Group[] m_components;
+
+        /// <summary>
+        /// Tracks whether allocated slots contain invalid components that can be compacted.
+        /// </summary>
+        private bool m_needRearrange;
         
         /// <summary>
         /// Gets the reference locator of this store.
@@ -421,16 +426,28 @@ namespace CoreECS.Managers
             var capa = m_components.Length;
             
             // Check if we need to expand the array
-            if (pos > MathF.Floor(capa * AutoIncreaseTriggerEdge) || pos >= capa)
+            if (NeedsMoreSpace(pos, capa))
             {
-                var newSize = (int) MathF.Floor(MathF.Max(pos + 1, MathF.Round(capa * AutoIncreaseRate)));
-                Array.Resize(ref m_components, newSize);
+                if (m_needRearrange)
+                {
+                    Rearrange();
+                    pos = Allocated;
+                    capa = m_components.Length;
+                }
+
+                if (NeedsMoreSpace(pos, capa))
+                {
+                    var newSize = (int) MathF.Floor(MathF.Max(pos + 1, MathF.Round(capa * AutoIncreaseRate)));
+                    Array.Resize(ref m_components, newSize);
+                }
             }
 
             ref var gs = ref m_components[pos];
+            var version = gs.Version;
+            gs = default;
             gs.Component = initialValue;
             gs.Entity = entityId;
-            gs.Version = (gs.Version % uint.MaxValue) + 1;
+            gs.Version = (version % uint.MaxValue) + 1;
 
             gs.RefCore = ComponentRefCore.Pool.Get();
             gs.RefCore.Allocate(RefLocator, pos, gs.Version);
@@ -446,6 +463,11 @@ namespace CoreECS.Managers
             }
             
             return pos;
+
+            bool NeedsMoreSpace(int position, int capacity)
+            {
+                return position > MathF.Floor(capacity * AutoIncreaseTriggerEdge) || position >= capacity;
+            }
         }
 
         /// <summary>
@@ -474,6 +496,7 @@ namespace CoreECS.Managers
             posGs.Entity = 0;
             ComponentRefCore.Pool.Release(posGs.RefCore);
             posGs.RefCore = null;
+            m_needRearrange = true;
             return true;
         }
 
@@ -482,6 +505,8 @@ namespace CoreECS.Managers
         /// </summary>
         public override void Rearrange()
         {
+            if (!m_needRearrange) return;
+
             var oldAllocated = Allocated;
             var left = 0;
             var right = oldAllocated - 1;
@@ -504,8 +529,7 @@ namespace CoreECS.Managers
             }
 
             Allocated = right + 1;
-            if (Allocated < oldAllocated)
-                Array.Clear(m_components, Allocated, oldAllocated - Allocated);
+            m_needRearrange = false;
         }
 
         /// <summary>

--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -162,6 +162,11 @@ namespace CoreECS.Managers
         public abstract int Rearrange();
 
         /// <summary>
+        /// Gets a value indicating whether this store contains invalid slots that can be compacted.
+        /// </summary>
+        public bool NeedRearrange { get; protected set; }
+
+        /// <summary>
         /// Sets the callbacks used by this store.
         /// </summary>
         /// <param name="callbackOnChanged">Callback to invoke on revision changes</param>
@@ -360,11 +365,6 @@ namespace CoreECS.Managers
         private Group[] m_components;
 
         /// <summary>
-        /// Tracks whether allocated slots contain invalid components that can be compacted.
-        /// </summary>
-        private bool m_needRearrange;
-        
-        /// <summary>
         /// Gets the reference locator of this store.
         /// </summary>
         public override IComponentRefLocator RefLocator
@@ -431,7 +431,7 @@ namespace CoreECS.Managers
             if (NeedsMoreSpace(pos, capa))
             {
                 var compactedCount = 0;
-                if (m_needRearrange)
+                if (NeedRearrange)
                 {
                     compactedCount = Rearrange();
                     pos = Allocated;
@@ -499,7 +499,7 @@ namespace CoreECS.Managers
             posGs.Entity = 0;
             ComponentRefCore.Pool.Release(posGs.RefCore);
             posGs.RefCore = null;
-            m_needRearrange = true;
+            NeedRearrange = true;
             return true;
         }
 
@@ -531,7 +531,7 @@ namespace CoreECS.Managers
             }
 
             Allocated = right + 1;
-            m_needRearrange = false;
+            NeedRearrange = false;
             return oldAllocated - Allocated;
         }
 
@@ -752,7 +752,8 @@ namespace CoreECS.Managers
         public void CleanupComponents()
         {
             foreach (var store in m_compStores.Values)
-                store.Rearrange();
+                if (store.NeedRearrange)
+                    store.Rearrange();
         }
 
         /// <summary>

--- a/ECS/World.cs
+++ b/ECS/World.cs
@@ -201,7 +201,7 @@ namespace CoreECS
         }
 
         /// <summary>
-        /// Collects the entity IDs of all live entities that currently have a <typeparamref name="TComp"/> instance,
+        /// Collects the non-zero entity IDs that currently have a <typeparamref name="TComp"/> instance,
         /// and appends each ID to <paramref name="result"/>.
         /// </summary>
         /// <typeparam name="TComp">The component type to query; must be a struct implementing <see cref="IComponent{TComp}"/>.</typeparam>
@@ -212,27 +212,24 @@ namespace CoreECS
         {
             Assertion.IsTrue(Ready, "World is not ready");
             
-            if (Entity == null || Component == null)
+            if (Component == null)
                 throw new InvalidOperationException("Core ECS managers are not available");
 
             var store = Component.GetComponentStore<TComp>();
             var ds = store.ComponentGroups;
             var count = store.Allocated;
-            var broken = 0;
+            var added = 0;
 
             for (var i = 0; i < count; i++)
             {
                 var entityId = ds[i].Entity;
-                if (Entity.GetEntity(entityId) == null)
-                {
-                    broken += 1;
-                    continue;
-                }
+                if (entityId == 0) continue;
 
                 result.Add(entityId);
+                added += 1;
             }
             
-            return count - broken;
+            return added;
         }
 
         /// <summary>
@@ -258,7 +255,13 @@ namespace CoreECS
 
             for (var i = 0; i < count; i++)
             {
-                var entityId = ds[i].Entity;                
+                var entityId = ds[i].Entity;
+                if (entityId == 0)
+                {
+                    broken += 1;
+                    continue;
+                }
+
                 var entityGraph = Entity.GetEntity(entityId);
                 if (entityGraph == null)
                 {

--- a/ECS/World.cs
+++ b/ECS/World.cs
@@ -201,30 +201,38 @@ namespace CoreECS
         }
 
         /// <summary>
-        /// Collects the entity IDs of all entities that currently have an allocated <typeparamref name="TComp"/> instance
-        /// in the component store, and appends each ID to <paramref name="result"/>.
+        /// Collects the entity IDs of all live entities that currently have a <typeparamref name="TComp"/> instance,
+        /// and appends each ID to <paramref name="result"/>.
         /// </summary>
         /// <typeparam name="TComp">The component type to query; must be a struct implementing <see cref="IComponent{TComp}"/>.</typeparam>
         /// <param name="result">The collection to append entity IDs to. Existing contents are not cleared.</param>
-        /// <returns>The number of allocated component entries for <typeparamref name="TComp"/> (equal to the number of IDs appended).</returns>
+        /// <returns>The number of entity IDs appended to <paramref name="result"/>.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the world is not ready or the component manager is not available.</exception>
         public int GetEntitiesWithComponent<TComp>(ICollection<ulong> result) where TComp : struct, IComponent<TComp>
         {
             Assertion.IsTrue(Ready, "World is not ready");
             
-            if (Component == null)
+            if (Entity == null || Component == null)
                 throw new InvalidOperationException("Core ECS managers are not available");
 
             var store = Component.GetComponentStore<TComp>();
             var ds = store.ComponentGroups;
             var count = store.Allocated;
+            var broken = 0;
 
             for (var i = 0; i < count; i++)
             {
-                result.Add(ds[i].Entity);
+                var entityId = ds[i].Entity;
+                if (Entity.GetEntity(entityId) == null)
+                {
+                    broken += 1;
+                    continue;
+                }
+
+                result.Add(entityId);
             }
             
-            return count;
+            return count - broken;
         }
 
         /// <summary>
@@ -240,7 +248,7 @@ namespace CoreECS
         {
             Assertion.IsTrue(Ready, "World is not ready");
             
-            if (Component == null)
+            if (Entity == null || Component == null)
                 throw new InvalidOperationException("Core ECS managers are not available");
 
             var store = Component.GetComponentStore<TComp>();

--- a/Test/ComponentManagerTestUnit.cs
+++ b/Test/ComponentManagerTestUnit.cs
@@ -263,12 +263,13 @@ namespace CoreECS.Test
             _componentManager.DestroyComponent(core2);
             _componentManager.DestroyComponent(core3);
 
+            Assert.IsTrue(store.NeedRearrange);
             var compacted = store.Rearrange();
 
             Assert.AreEqual(2, compacted);
             Assert.AreEqual(1, store.Allocated);
             Assert.IsTrue(core1.RefLocator.NotNull(core1.Version, core1.Offset));
-            Assert.AreEqual(0, store.Rearrange());
+            Assert.IsFalse(store.NeedRearrange);
         }
         
         [Test]
@@ -446,7 +447,9 @@ namespace CoreECS.Test
             // Remove components and trigger rearrangement
             _componentManager.DestroyComponent(posCore1);
             _componentManager.DestroyComponent(posCore3);
-            _componentManager.GetComponentStore<PositionComponent>().Rearrange();
+            var store = _componentManager.GetComponentStore<PositionComponent>();
+            if (store.NeedRearrange)
+                store.Rearrange();
             
             // Modify the cached value
             cachedPosition.X = 75.0f;

--- a/Test/ComponentManagerTestUnit.cs
+++ b/Test/ComponentManagerTestUnit.cs
@@ -251,6 +251,25 @@ namespace CoreECS.Test
             for (var i = 0; i < store.Allocated; i++)
                 Assert.AreNotEqual(0UL, store.ComponentGroups[i].Entity);
         }
+
+        [Test]
+        public void ComponentManager_ComponentStore_Rearrange_ReturnsCompactedSlotCount()
+        {
+            var store = _componentManager.GetComponentStore<PositionComponent>();
+            var core1 = _componentManager.CreateComponent<PositionComponent>(_world.CreateEntity().EntityId);
+            var core2 = _componentManager.CreateComponent<PositionComponent>(_world.CreateEntity().EntityId);
+            var core3 = _componentManager.CreateComponent<PositionComponent>(_world.CreateEntity().EntityId);
+
+            _componentManager.DestroyComponent(core2);
+            _componentManager.DestroyComponent(core3);
+
+            var compacted = store.Rearrange();
+
+            Assert.AreEqual(2, compacted);
+            Assert.AreEqual(1, store.Allocated);
+            Assert.IsTrue(core1.RefLocator.NotNull(core1.Version, core1.Offset));
+            Assert.AreEqual(0, store.Rearrange());
+        }
         
         [Test]
         public void ComponentManager_ComponentStore_ExpandMethod_IncreasesCapacity()

--- a/Test/ComponentManagerTestUnit.cs
+++ b/Test/ComponentManagerTestUnit.cs
@@ -226,6 +226,31 @@ namespace CoreECS.Test
             Assert.Greater(store.Capacity, initialCapacity);
             Assert.AreEqual(initialCapacity + 10, store.Allocated);
         }
+
+        [Test]
+        public void ComponentManager_ComponentStore_RearrangesBeforeExpandingWhenInvalidSlotsExist()
+        {
+            var store = _componentManager.GetComponentStore<PositionComponent>();
+            var initialCapacity = store.Capacity;
+            var cores = new List<IComponentRefCore>(initialCapacity);
+
+            for (var i = 0; i < initialCapacity; i++)
+            {
+                var entity = _world.CreateEntity();
+                cores.Add(_componentManager.CreateComponent<PositionComponent>(entity.EntityId));
+            }
+
+            for (var i = 0; i < initialCapacity; i += 2)
+                _componentManager.DestroyComponent(cores[i]);
+
+            _componentManager.CreateComponent<PositionComponent>(_world.CreateEntity().EntityId);
+
+            Assert.AreEqual(initialCapacity, store.Capacity);
+            Assert.AreEqual(initialCapacity / 2 + 1, store.Allocated);
+
+            for (var i = 0; i < store.Allocated; i++)
+                Assert.AreNotEqual(0UL, store.ComponentGroups[i].Entity);
+        }
         
         [Test]
         public void ComponentManager_ComponentStore_ExpandMethod_IncreasesCapacity()

--- a/Test/WorldTestUnit.cs
+++ b/Test/WorldTestUnit.cs
@@ -319,6 +319,34 @@ namespace CoreECS.Test
         }
 
         [Test]
+        public void World_GetEntitiesWithComponent_Ulong_SkipsReleasedAndStaleEntityIdsBeforeCleanup()
+        {
+            var world = new World();
+            world.Startup();
+
+            var alive = world.CreateEntity();
+            var componentReleased = world.CreateEntity();
+            var entityDestroyed = world.CreateEntity();
+
+            alive.CreateComponent<PositionComponent>();
+            var releasedRef = componentReleased.CreateComponent<PositionComponent>();
+            entityDestroyed.CreateComponent<PositionComponent>();
+
+            componentReleased.DestroyComponent(releasedRef);
+            world.DestroyEntity(entityDestroyed);
+
+            var ids = new List<ulong>();
+            var returned = world.GetEntitiesWithComponent<PositionComponent>(ids);
+
+            Assert.AreEqual(1, returned);
+            CollectionAssert.AreEqual(new[] { alive.EntityId }, ids);
+            CollectionAssert.DoesNotContain(ids, 0UL);
+            CollectionAssert.DoesNotContain(ids, entityDestroyed.EntityId);
+
+            world.Shutdown();
+        }
+
+        [Test]
         public void World_GetEntitiesWithComponent_Entity_ReturnsValidHandlesMatchingIds()
         {
             var world = new World();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Make `GetEntitiesWithComponent<TComp>(ICollection<ulong>)` skip invalid `EntityId == 0` component slots without resolving entities through `EntityManager`.
- Remove `ComponentStore`'s cleanup-position list and expose `NeedRearrange` as public get/protected set state for callers to guard compaction.
- Use a non-stable two-pointer `Rearrange` compaction so valid tail slots fill earlier invalid slots without preserving component-store order, returning the number of compacted slots.
- Clean a slot immediately before assigning a new component, and compact invalid slots before expanding storage when capacity is otherwise exhausted.
- Add regression tests covering released component slots, destroyed entities before component cleanup, rearranging before expansion, `Rearrange` return counts, and `NeedRearrange` transitions.
- Rebased the branch onto latest `master`.

### Testing
- `dotnet test --filter GetEntitiesWithComponent --verbosity normal` with `ECS/World.cs` temporarily restored to `master`: failed the new regression test as expected.
- `dotnet test --verbosity normal` with `ECS/World.cs` temporarily restored to `master`: failed only the new regression test as expected.
- `dotnet test --filter "GetEntitiesWithComponent|ComponentManager" --verbosity normal`
- `dotnet test --verbosity normal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-254a7def-0b0e-42c6-9294-73702e0af8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-254a7def-0b0e-42c6-9294-73702e0af8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

