### PR TITLE
fix(core): keep entity validity probe safe after shutdown

### DIFF
--- a/ECS/Entity.cs
+++ b/ECS/Entity.cs
@@ -96,15 +96,14 @@ namespace CoreECS
         public IWorld World => m_world ?? throw new InvalidOperationException("Entity is not associated with any world.");
 
         /// <summary>
-        /// Gets a value indicating whether this entity is still valid (not destroyed and not recycled).
+        /// Gets a value indicating whether this entity is still valid (not destroyed, not recycled, and not shut down).
         /// </summary>
         public bool IsValid
         {
             get
             {
-                if (m_world == null) return false;
-                var entityManager = m_world.GetManager<EntityManager>();
-                if (!entityManager.EntityCaches.TryGetValue(m_entityId, out var graph)) return false;
+                if (m_entityManager == null) return false;
+                if (!m_entityManager.EntityCaches.TryGetValue(m_entityId, out var graph)) return false;
                 return graph.Generation == m_generation;
             }
         }

--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -165,11 +165,6 @@ namespace CoreECS.Managers
         /// </summary>
         /// <param name="callbackOnChanged">Callback to invoke on revision changes</param>
         public abstract void SetCallbacks(Action<IComponentRefCore, ulong> callbackOnChanged);
-
-        /// <summary>
-        /// Marks existing component references as invalid when the owning manager is destroyed.
-        /// </summary>
-        internal abstract void InvalidateReferences();
     }
 
     /// <summary>
@@ -230,8 +225,6 @@ namespace CoreECS.Managers
             /// <returns>True if the component reference is valid and not null, false otherwise</returns>
             public bool NotNull(uint version, int offset)
             {
-                if (m_store.m_shutdown) return false;
-                if (offset < 0) return false;
                 if (offset >= m_store.Allocated) return false;
                 ref var g = ref m_store.m_components[offset];
                 
@@ -356,11 +349,6 @@ namespace CoreECS.Managers
         /// Callback invoked when a component revision changes.
         /// </summary>
         private Action<IComponentRefCore, ulong> m_revisionChanged;
-
-        /// <summary>
-        /// Indicates whether references from this store should be treated as invalid.
-        /// </summary>
-        private bool m_shutdown;
         
         /// <summary>
         /// Array of component groups containing component data and metadata.
@@ -521,11 +509,6 @@ namespace CoreECS.Managers
         public override void SetCallbacks(Action<IComponentRefCore, ulong> callbackOnChanged)
         {
             m_revisionChanged = callbackOnChanged;
-        }
-
-        internal override void InvalidateReferences()
-        {
-            m_shutdown = true;
         }
 
         /// <summary>
@@ -767,10 +750,6 @@ namespace CoreECS.Managers
         /// <summary>
         /// Called when the manager is destroyed.
         /// </summary>
-        public void OnManagerDestroyed()
-        {
-            foreach (var store in m_compStores.Values)
-                store.InvalidateReferences();
-        }
+        public void OnManagerDestroyed() {}
     }
 }

--- a/ECS/Managers/ComponentManager.cs
+++ b/ECS/Managers/ComponentManager.cs
@@ -165,6 +165,11 @@ namespace CoreECS.Managers
         /// </summary>
         /// <param name="callbackOnChanged">Callback to invoke on revision changes</param>
         public abstract void SetCallbacks(Action<IComponentRefCore, ulong> callbackOnChanged);
+
+        /// <summary>
+        /// Marks existing component references as invalid when the owning manager is destroyed.
+        /// </summary>
+        internal abstract void InvalidateReferences();
     }
 
     /// <summary>
@@ -225,6 +230,8 @@ namespace CoreECS.Managers
             /// <returns>True if the component reference is valid and not null, false otherwise</returns>
             public bool NotNull(uint version, int offset)
             {
+                if (m_store.m_shutdown) return false;
+                if (offset < 0) return false;
                 if (offset >= m_store.Allocated) return false;
                 ref var g = ref m_store.m_components[offset];
                 
@@ -349,6 +356,11 @@ namespace CoreECS.Managers
         /// Callback invoked when a component revision changes.
         /// </summary>
         private Action<IComponentRefCore, ulong> m_revisionChanged;
+
+        /// <summary>
+        /// Indicates whether references from this store should be treated as invalid.
+        /// </summary>
+        private bool m_shutdown;
         
         /// <summary>
         /// Array of component groups containing component data and metadata.
@@ -509,6 +521,11 @@ namespace CoreECS.Managers
         public override void SetCallbacks(Action<IComponentRefCore, ulong> callbackOnChanged)
         {
             m_revisionChanged = callbackOnChanged;
+        }
+
+        internal override void InvalidateReferences()
+        {
+            m_shutdown = true;
         }
 
         /// <summary>
@@ -750,6 +767,10 @@ namespace CoreECS.Managers
         /// <summary>
         /// Called when the manager is destroyed.
         /// </summary>
-        public void OnManagerDestroyed() {}
+        public void OnManagerDestroyed()
+        {
+            foreach (var store in m_compStores.Values)
+                store.InvalidateReferences();
+        }
     }
 }

--- a/Test/EntityTestUnit.cs
+++ b/Test/EntityTestUnit.cs
@@ -58,6 +58,21 @@ namespace CoreECS.Test
             // Assert
             Assert.DoesNotThrow(() => Assert.IsFalse(entity.IsValid));
         }
+
+        [Test]
+        public void ComponentRef_NotNullAfterWorldShutdown_ReturnsFalse()
+        {
+            // Arrange
+            var entity = _world.CreateEntity();
+            var component = entity.CreateComponent<PositionComponent>();
+
+            // Act
+            _world.Shutdown();
+            _world = null;
+
+            // Assert
+            Assert.DoesNotThrow(() => Assert.IsFalse(component.NotNull));
+        }
         
         [Test]
         public void Entity_CanAccessMask()

--- a/Test/EntityTestUnit.cs
+++ b/Test/EntityTestUnit.cs
@@ -60,21 +60,6 @@ namespace CoreECS.Test
         }
 
         [Test]
-        public void ComponentRef_NotNullAfterWorldShutdown_ReturnsFalse()
-        {
-            // Arrange
-            var entity = _world.CreateEntity();
-            var component = entity.CreateComponent<PositionComponent>();
-
-            // Act
-            _world.Shutdown();
-            _world = null;
-
-            // Assert
-            Assert.DoesNotThrow(() => Assert.IsFalse(component.NotNull));
-        }
-        
-        [Test]
         public void Entity_CanAccessMask()
         {
             // Arrange

--- a/Test/EntityTestUnit.cs
+++ b/Test/EntityTestUnit.cs
@@ -44,6 +44,20 @@ namespace CoreECS.Test
             // Assert
             Assert.IsFalse(entity.IsValid);
         }
+
+        [Test]
+        public void Entity_IsValidAfterWorldShutdown_ReturnsFalse()
+        {
+            // Arrange
+            var entity = _world.CreateEntity();
+
+            // Act
+            _world.Shutdown();
+            _world = null;
+
+            // Assert
+            Assert.DoesNotThrow(() => Assert.IsFalse(entity.IsValid));
+        }
         
         [Test]
         public void Entity_CanAccessMask()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Use the cached `EntityManager` inside `Entity.IsValid` so validity probes do not call `World.GetManager` after shutdown.
- Add a regression test that verifies an entity handle returns `false` without throwing after its world shuts down.

### Testing
- `dotnet test --filter Entity_IsValidAfterWorldShutdown_ReturnsFalse --verbosity normal`
- `dotnet test --verbosity normal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d0466a2-dbc9-440b-b8b0-5d5caf8befec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d0466a2-dbc9-440b-b8b0-5d5caf8befec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

