### PR TITLE
feat(core): replace GetEntities APIs with matcher-based Query

### DIFF
--- a/ECS/EntityMatcherExtension.cs
+++ b/ECS/EntityMatcherExtension.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using CoreECS.Defines;
 
 namespace CoreECS
@@ -451,6 +452,38 @@ namespace CoreECS
             World world, EntityCollectorFlag flag = EntityCollectorFlag.Default)
         {
             return world.CreateCollector(matcher, flag);
+        }
+
+        /// <summary>
+        /// Appends IDs of entities that match <paramref name="matcher"/> to <paramref name="result"/>.
+        /// Existing items in <paramref name="result"/> are preserved.
+        /// </summary>
+        /// <param name="matcher">Matcher used to filter entities.</param>
+        /// <param name="world">World that owns queried entities.</param>
+        /// <param name="result">Target non-alloc output collection.</param>
+        /// <returns>The number of IDs appended.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the world is not ready or managers are unavailable.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown when matcher, world, or result is null.</exception>
+        public static int Query(this IEntityMatcher matcher, World world, ICollection<ulong> result)
+        {
+            CoreECS.Utils.Assertion.ArgumentNotNull(world, nameof(world));
+            return world.Query(matcher, result);
+        }
+
+        /// <summary>
+        /// Appends entities that match <paramref name="matcher"/> to <paramref name="result"/>.
+        /// Existing items in <paramref name="result"/> are preserved.
+        /// </summary>
+        /// <param name="matcher">Matcher used to filter entities.</param>
+        /// <param name="world">World that owns queried entities.</param>
+        /// <param name="result">Target non-alloc output collection.</param>
+        /// <returns>The number of entities appended.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the world is not ready or managers are unavailable.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown when matcher, world, or result is null.</exception>
+        public static int Query(this IEntityMatcher matcher, World world, ICollection<Entity> result)
+        {
+            CoreECS.Utils.Assertion.ArgumentNotNull(world, nameof(world));
+            return world.Query(matcher, result);
         }
     }
 }

--- a/ECS/World.cs
+++ b/ECS/World.cs
@@ -207,7 +207,7 @@ namespace CoreECS
         /// <param name="matcher">Matcher that defines the query conditions.</param>
         /// <param name="result">Target collection used as non-alloc output.</param>
         /// <returns>The number of matched entities appended to <paramref name="result"/>.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or managers are unavailable.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or the entity manager is unavailable.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="matcher"/> or <paramref name="result"/> is null.</exception>
         public int Query(IEntityMatcher matcher, ICollection<ulong> result)
         {
@@ -237,7 +237,7 @@ namespace CoreECS
         /// <param name="matcher">Matcher that defines the query conditions.</param>
         /// <param name="result">Target collection used as non-alloc output.</param>
         /// <returns>The number of matched entities appended to <paramref name="result"/>.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or managers are unavailable.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or required managers are unavailable.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="matcher"/> or <paramref name="result"/> is null.</exception>
         public int Query(IEntityMatcher matcher, ICollection<Entity> result)
         {

--- a/ECS/World.cs
+++ b/ECS/World.cs
@@ -201,78 +201,63 @@ namespace CoreECS
         }
 
         /// <summary>
-        /// Collects the non-zero entity IDs that currently have a <typeparamref name="TComp"/> instance,
-        /// and appends each ID to <paramref name="result"/>.
+        /// Appends entity IDs that match the specified matcher to <paramref name="result"/>.
+        /// Existing items in <paramref name="result"/> are preserved.
         /// </summary>
-        /// <typeparam name="TComp">The component type to query; must be a struct implementing <see cref="IComponent{TComp}"/>.</typeparam>
-        /// <param name="result">The collection to append entity IDs to. Existing contents are not cleared.</param>
-        /// <returns>The number of entity IDs appended to <paramref name="result"/>.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or the component manager is not available.</exception>
-        public int GetEntitiesWithComponent<TComp>(ICollection<ulong> result) where TComp : struct, IComponent<TComp>
+        /// <param name="matcher">Matcher that defines the query conditions.</param>
+        /// <param name="result">Target collection used as non-alloc output.</param>
+        /// <returns>The number of matched entities appended to <paramref name="result"/>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or managers are unavailable.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="matcher"/> or <paramref name="result"/> is null.</exception>
+        public int Query(IEntityMatcher matcher, ICollection<ulong> result)
         {
             Assertion.IsTrue(Ready, "World is not ready");
+            Assertion.ArgumentNotNull(matcher, nameof(matcher));
+            Assertion.ArgumentNotNull(result, nameof(result));
             
-            if (Component == null)
+            if (Entity == null)
                 throw new InvalidOperationException("Core ECS managers are not available");
 
-            var store = Component.GetComponentStore<TComp>();
-            var ds = store.ComponentGroups;
-            var count = store.Allocated;
             var added = 0;
-
-            for (var i = 0; i < count; i++)
+            foreach (var entityGraph in Entity.EntityCaches.Values)
             {
-                var entityId = ds[i].Entity;
-                if (entityId == 0) continue;
-
-                result.Add(entityId);
+                if (!_isMatched(entityGraph, matcher)) continue;
+                
+                result.Add(entityGraph.EntityId);
                 added += 1;
             }
-            
+
             return added;
         }
 
         /// <summary>
-        /// Collects <see cref="Entity"/> handles for all entities that currently have an allocated <typeparamref name="TComp"/>
-        /// instance in the component store, and appends each valid handle to <paramref name="result"/>.
-        /// Store entries that no longer resolve to a live entity graph are skipped.
+        /// Appends entity handles that match the specified matcher to <paramref name="result"/>.
+        /// Existing items in <paramref name="result"/> are preserved.
         /// </summary>
-        /// <typeparam name="TComp">The component type to query; must be a struct implementing <see cref="IComponent{TComp}"/>.</typeparam>
-        /// <param name="result">The collection to append <see cref="Entity"/> values to. Existing contents are not cleared.</param>
-        /// <returns>The number of <see cref="Entity"/> values appended to <paramref name="result"/>.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or the component manager is not available.</exception>
-        public int GetEntitiesWithComponent<TComp>(ICollection<Entity> result) where TComp : struct, IComponent<TComp>
+        /// <param name="matcher">Matcher that defines the query conditions.</param>
+        /// <param name="result">Target collection used as non-alloc output.</param>
+        /// <returns>The number of matched entities appended to <paramref name="result"/>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the world is not ready or managers are unavailable.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="matcher"/> or <paramref name="result"/> is null.</exception>
+        public int Query(IEntityMatcher matcher, ICollection<Entity> result)
         {
             Assertion.IsTrue(Ready, "World is not ready");
+            Assertion.ArgumentNotNull(matcher, nameof(matcher));
+            Assertion.ArgumentNotNull(result, nameof(result));
             
             if (Entity == null || Component == null)
                 throw new InvalidOperationException("Core ECS managers are not available");
 
-            var store = Component.GetComponentStore<TComp>();
-            var ds = store.ComponentGroups;
-            var count = store.Allocated;
-            var broken = 0;
-
-            for (var i = 0; i < count; i++)
+            var added = 0;
+            foreach (var entityGraph in Entity.EntityCaches.Values)
             {
-                var entityId = ds[i].Entity;
-                if (entityId == 0)
-                {
-                    broken += 1;
-                    continue;
-                }
-
-                var entityGraph = Entity.GetEntity(entityId);
-                if (entityGraph == null)
-                {
-                    broken += 1;
-                    continue;
-                }
+                if (!_isMatched(entityGraph, matcher)) continue;
                 
-                result.Add(new Entity(this, entityId, entityGraph.Generation, Entity, Component));
+                result.Add(new Entity(this, entityGraph.EntityId, entityGraph.Generation, Entity, Component));
+                added += 1;
             }
-            
-            return count - broken;
+
+            return added;
         }
 
         /// <summary>
@@ -353,6 +338,16 @@ namespace CoreECS
                 throw new InvalidOperationException("Core ECS managers are not available");
             
             return EntityMatch.MakeCollector(flag, matcher);
+        }
+
+        /// <summary>
+        /// Shared matcher gate for world-level non-alloc entity queries.
+        /// </summary>
+        private static bool _isMatched(EntityGraph entityGraph, IEntityMatcher matcher)
+        {
+            if ((matcher.EntityMask & entityGraph.Mask) == 0) return false;
+            if (entityGraph.WishDestroy) return false;
+            return matcher.ComponentFilter(entityGraph.RwComponents);
         }
 
         #endregion

--- a/Test/EntityMatcherTestUnit.cs
+++ b/Test/EntityMatcherTestUnit.cs
@@ -1,5 +1,4 @@
 using CoreECS.Defines;
-using CoreECS.Managers;
 
 namespace CoreECS.Test
 {
@@ -37,23 +36,14 @@ namespace CoreECS.Test
             var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert
             Assert.AreEqual(2, matchedEntities.Count);
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity1.EntityId));
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity2.EntityId));
-            Assert.IsFalse(matchedEntities.Exists(e => e.EntityId == entity3.EntityId));
+            CollectionAssert.Contains(matchedEntities, entity1.EntityId);
+            CollectionAssert.Contains(matchedEntities, entity2.EntityId);
+            CollectionAssert.DoesNotContain(matchedEntities, entity3.EntityId);
         }
         
         [Test]
@@ -71,23 +61,14 @@ namespace CoreECS.Test
             var matcher = EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert
             Assert.AreEqual(2, matchedEntities.Count);
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity1.EntityId));
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity2.EntityId));
-            Assert.IsFalse(matchedEntities.Exists(e => e.EntityId == entity3.EntityId));
+            CollectionAssert.Contains(matchedEntities, entity1.EntityId);
+            CollectionAssert.Contains(matchedEntities, entity2.EntityId);
+            CollectionAssert.DoesNotContain(matchedEntities, entity3.EntityId);
         }
         
         [Test]
@@ -106,23 +87,14 @@ namespace CoreECS.Test
             var matcher = EntityMatcher.With.OfAll<PositionComponent>().OfNone<VelocityComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert
             Assert.AreEqual(1, matchedEntities.Count);
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity1.EntityId));
-            Assert.IsFalse(matchedEntities.Exists(e => e.EntityId == entity2.EntityId));
-            Assert.IsFalse(matchedEntities.Exists(e => e.EntityId == entity3.EntityId));
+            CollectionAssert.Contains(matchedEntities, entity1.EntityId);
+            CollectionAssert.DoesNotContain(matchedEntities, entity2.EntityId);
+            CollectionAssert.DoesNotContain(matchedEntities, entity3.EntityId);
         }
         
         [Test]
@@ -136,23 +108,14 @@ namespace CoreECS.Test
             var matcher = EntityMatcher.WithMask(0b0001); // Match entities with bit 0 set
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if ((entity.Mask & matcher.EntityMask) == matcher.EntityMask)
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert
             Assert.AreEqual(2, matchedEntities.Count);
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity1.EntityId));
-            Assert.IsFalse(matchedEntities.Exists(e => e.EntityId == entity2.EntityId));
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity3.EntityId));
+            CollectionAssert.Contains(matchedEntities, entity1.EntityId);
+            CollectionAssert.DoesNotContain(matchedEntities, entity2.EntityId);
+            CollectionAssert.Contains(matchedEntities, entity3.EntityId);
         }
         
         [Test]
@@ -244,17 +207,8 @@ namespace CoreECS.Test
             var matcher = EntityMatcher.With.OfAny<PositionComponent>().OfAny<VelocityComponent>().OfAny<HealthComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert
             Assert.AreEqual(4, matchedEntities.Count); // All entities should match
@@ -278,21 +232,12 @@ namespace CoreECS.Test
             var matcher = EntityMatcher.With.OfNone<PositionComponent>().OfNone<VelocityComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert
             Assert.AreEqual(1, matchedEntities.Count); // Only entity3 should match
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity3.EntityId));
+            CollectionAssert.Contains(matchedEntities, entity3.EntityId);
         }
         
         [Test]
@@ -332,17 +277,8 @@ namespace CoreECS.Test
                 .OfNone<HealthComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert - Only entities with Position AND (Velocity OR Health) BUT NOT both should match
             // Since OfNone excludes entities with either component, no entities should match
@@ -384,21 +320,12 @@ namespace CoreECS.Test
                 .OfNone<HealthComponent>();
             
             // Act
-            var entityManager = _world.GetManager<EntityManager>();
-            var matchedEntities = new List<Entity>();
-            
-            foreach (var kvp in entityManager.EntityCaches)
-            {
-                var entity = new Entity(_world, kvp.Key, kvp.Value.Generation);
-                if (matcher.ComponentFilter(kvp.Value.GetComponents().Select(x => x.Core).ToArray()))
-                {
-                    matchedEntities.Add(entity);
-                }
-            }
+            var matchedEntities = new List<ulong>();
+            _world.Query(matcher, matchedEntities);
             
             // Assert - Only entity2 should match (has Position and Velocity but not Health)
             Assert.AreEqual(1, matchedEntities.Count);
-            Assert.IsTrue(matchedEntities.Exists(e => e.EntityId == entity2.EntityId));
+            CollectionAssert.Contains(matchedEntities, entity2.EntityId);
         }
         
         [Test]

--- a/Test/WorldTestUnit.cs
+++ b/Test/WorldTestUnit.cs
@@ -380,6 +380,28 @@ namespace CoreECS.Test
         }
 
         [Test]
+        public void World_Query_Ulong_DoesNotReturnDestroyedEntities()
+        {
+            var world = new World();
+            world.Startup();
+
+            var alive = world.CreateEntity();
+            var destroyed = world.CreateEntity();
+            alive.CreateComponent<PositionComponent>();
+            destroyed.CreateComponent<PositionComponent>();
+            world.DestroyEntity(destroyed);
+
+            var ids = new List<ulong>();
+            var returned = world.Query(EntityMatcher.With.OfAll<PositionComponent>(), ids);
+
+            Assert.AreEqual(1, returned);
+            CollectionAssert.AreEqual(new[] { alive.EntityId }, ids);
+            CollectionAssert.DoesNotContain(ids, destroyed.EntityId);
+
+            world.Shutdown();
+        }
+
+        [Test]
         public void World_Query_ThrowsWhenWorldNotReady_UlongCollection()
         {
             var world = new World();
@@ -420,6 +442,43 @@ namespace CoreECS.Test
             Assert.Throws<ArgumentNullException>(() => world.Query(matcher, (ICollection<Entity>)null));
 
             world.Shutdown();
+        }
+
+        [Test]
+        public void EntityMatcherExtension_Query_DelegatesToWorldQuery()
+        {
+            var world = new World();
+            world.Startup();
+
+            var e1 = world.CreateEntity();
+            var e2 = world.CreateEntity();
+            e1.CreateComponent<PositionComponent>();
+            e2.CreateComponent<VelocityComponent>();
+            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
+
+            var ids = new List<ulong>();
+            var idCount = matcher.Query(world, ids);
+            Assert.AreEqual(1, idCount);
+            CollectionAssert.AreEqual(new[] { e1.EntityId }, ids);
+
+            var entities = new List<Entity>();
+            var entityCount = matcher.Query(world, entities);
+            Assert.AreEqual(1, entityCount);
+            Assert.AreEqual(e1.EntityId, entities[0].EntityId);
+            Assert.IsTrue(entities[0].IsValid);
+
+            world.Shutdown();
+        }
+
+        [Test]
+        public void EntityMatcherExtension_Query_ThrowsWhenWorldIsNull()
+        {
+            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                matcher.Query((World)null, new List<ulong>()));
+            Assert.Throws<ArgumentNullException>(() =>
+                matcher.Query((World)null, new List<Entity>()));
         }
         
         [Test]

--- a/Test/WorldTestUnit.cs
+++ b/Test/WorldTestUnit.cs
@@ -275,30 +275,30 @@ namespace CoreECS.Test
         }
 
         [Test]
-        public void World_GetEntitiesWithComponent_Ulong_ReturnsIdsForEntitiesWithComponent()
+        public void World_Query_Ulong_ReturnsIdsForEntitiesMatchingMatcher()
         {
             var world = new World();
             world.Startup();
 
-            var withA = world.CreateEntity();
-            var withB = world.CreateEntity();
+            var withPositionA = world.CreateEntity();
+            var withPositionB = world.CreateEntity();
             _ = world.CreateEntity();
 
-            withA.CreateComponent<PositionComponent>();
-            withB.CreateComponent<PositionComponent>();
+            withPositionA.CreateComponent<PositionComponent>();
+            withPositionB.CreateComponent<PositionComponent>();
 
             var ids = new List<ulong>();
-            var returned = world.GetEntitiesWithComponent<PositionComponent>(ids);
+            var returned = world.Query(EntityMatcher.With.OfAll<PositionComponent>(), ids);
 
             Assert.AreEqual(2, returned);
             Assert.AreEqual(2, ids.Count);
-            CollectionAssert.AreEquivalent(new[] { withA.EntityId, withB.EntityId }, ids);
+            CollectionAssert.AreEquivalent(new[] { withPositionA.EntityId, withPositionB.EntityId }, ids);
 
             world.Shutdown();
         }
 
         [Test]
-        public void World_GetEntitiesWithComponent_Ulong_AppendsToExistingCollection()
+        public void World_Query_Ulong_AppendsToExistingCollection()
         {
             var world = new World();
             world.Startup();
@@ -308,7 +308,7 @@ namespace CoreECS.Test
 
             const ulong sentinel = 42;
             var ids = new List<ulong> { sentinel };
-            var returned = world.GetEntitiesWithComponent<PositionComponent>(ids);
+            var returned = world.Query(EntityMatcher.With.OfAll<PositionComponent>(), ids);
 
             Assert.AreEqual(1, returned);
             Assert.AreEqual(2, ids.Count);
@@ -319,35 +319,34 @@ namespace CoreECS.Test
         }
 
         [Test]
-        public void World_GetEntitiesWithComponent_Ulong_SkipsReleasedAndStaleEntityIdsBeforeCleanup()
+        public void World_Query_Ulong_HonorsMaskAndComponentRules()
         {
             var world = new World();
             world.Startup();
 
-            var alive = world.CreateEntity();
-            var componentReleased = world.CreateEntity();
-            var entityDestroyed = world.CreateEntity();
+            var expected = world.CreateEntity(0b0001);
+            var wrongMask = world.CreateEntity(0b0010);
+            var excludedByNone = world.CreateEntity(0b0001);
 
-            alive.CreateComponent<PositionComponent>();
-            var releasedRef = componentReleased.CreateComponent<PositionComponent>();
-            entityDestroyed.CreateComponent<PositionComponent>();
+            expected.CreateComponent<PositionComponent>();
+            wrongMask.CreateComponent<PositionComponent>();
+            excludedByNone.CreateComponent<PositionComponent>();
+            excludedByNone.CreateComponent<VelocityComponent>();
 
-            componentReleased.DestroyComponent(releasedRef);
-            world.DestroyEntity(entityDestroyed);
-
+            var matcher = EntityMatcher.WithMask(0b0001)
+                .OfAll<PositionComponent>()
+                .OfNone<VelocityComponent>();
             var ids = new List<ulong>();
-            var returned = world.GetEntitiesWithComponent<PositionComponent>(ids);
+            var returned = world.Query(matcher, ids);
 
             Assert.AreEqual(1, returned);
-            CollectionAssert.AreEqual(new[] { alive.EntityId }, ids);
-            CollectionAssert.DoesNotContain(ids, 0UL);
-            CollectionAssert.DoesNotContain(ids, entityDestroyed.EntityId);
+            CollectionAssert.AreEqual(new[] { expected.EntityId }, ids);
 
             world.Shutdown();
         }
 
         [Test]
-        public void World_GetEntitiesWithComponent_Entity_ReturnsValidHandlesMatchingIds()
+        public void World_Query_Entity_ReturnsValidHandlesMatchingIds()
         {
             var world = new World();
             world.Startup();
@@ -357,11 +356,12 @@ namespace CoreECS.Test
             e1.CreateComponent<PositionComponent>();
             e2.CreateComponent<PositionComponent>();
 
+            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
             var ulongIds = new List<ulong>();
-            var ulongCount = world.GetEntitiesWithComponent<PositionComponent>(ulongIds);
+            var ulongCount = world.Query(matcher, ulongIds);
 
             var entities = new List<Entity>();
-            var entityCount = world.GetEntitiesWithComponent<PositionComponent>(entities);
+            var entityCount = world.Query(matcher, entities);
 
             Assert.AreEqual(ulongCount, entityCount);
 
@@ -380,21 +380,46 @@ namespace CoreECS.Test
         }
 
         [Test]
-        public void World_GetEntitiesWithComponent_ThrowsWhenWorldNotReady_UlongCollection()
+        public void World_Query_ThrowsWhenWorldNotReady_UlongCollection()
         {
             var world = new World();
 
             Assert.Throws<InvalidOperationException>(() =>
-                world.GetEntitiesWithComponent<PositionComponent>(new List<ulong>()));
+                world.Query(EntityMatcher.With.OfAll<PositionComponent>(), new List<ulong>()));
         }
 
         [Test]
-        public void World_GetEntitiesWithComponent_ThrowsWhenWorldNotReady_EntityCollection()
+        public void World_Query_ThrowsWhenWorldNotReady_EntityCollection()
         {
             var world = new World();
 
             Assert.Throws<InvalidOperationException>(() =>
-                world.GetEntitiesWithComponent<PositionComponent>(new List<Entity>()));
+                world.Query(EntityMatcher.With.OfAll<PositionComponent>(), new List<Entity>()));
+        }
+
+        [Test]
+        public void World_Query_ThrowsWhenMatcherIsNull()
+        {
+            var world = new World();
+            world.Startup();
+
+            Assert.Throws<ArgumentNullException>(() => world.Query((IEntityMatcher)null, new List<ulong>()));
+            Assert.Throws<ArgumentNullException>(() => world.Query((IEntityMatcher)null, new List<Entity>()));
+
+            world.Shutdown();
+        }
+
+        [Test]
+        public void World_Query_ThrowsWhenResultIsNull()
+        {
+            var world = new World();
+            world.Startup();
+            var matcher = EntityMatcher.With.OfAll<PositionComponent>();
+
+            Assert.Throws<ArgumentNullException>(() => world.Query(matcher, (ICollection<ulong>)null));
+            Assert.Throws<ArgumentNullException>(() => world.Query(matcher, (ICollection<Entity>)null));
+
+            world.Shutdown();
         }
         
         [Test]
@@ -615,6 +640,11 @@ namespace CoreECS.Test
         
         // Test component for collector tests
         private struct PositionComponent : IComponent<PositionComponent>
+        {
+            public float X, Y;
+        }
+
+        private struct VelocityComponent : IComponent<VelocityComponent>
         {
             public float X, Y;
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `World.Query(IEntityMatcher, ICollection<ulong>)` and `World.Query(IEntityMatcher, ICollection<Entity>)` as the unified non-alloc query entrypoints.
- Remove `World.GetEntitiesWithComponent<TComp>(...)` overloads and migrate query tests/call sites to matcher-driven APIs.
- Add matcher-centric extension overloads: `matcher.Query(world, result)` for IDs and entities.
- Refactor matcher unit tests to use `World.Query` instead of manual `EntityManager.EntityCaches` scans.
- Add regression tests for destroyed-entity filtering, argument validation, and extension method null/world behavior.

## Verification
- `dotnet test Test/Test.csproj --filter "FullyQualifiedName~WorldTestUnit|FullyQualifiedName~EntityMatcherTestUnit" --verbosity normal`
- `dotnet test --verbosity normal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10952748-c2a1-476f-a6fb-f02cb78a8c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10952748-c2a1-476f-a6fb-f02cb78a8c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

